### PR TITLE
Add manifest type to scratch images

### DIFF
--- a/pkg/image/mutable_source.go
+++ b/pkg/image/mutable_source.go
@@ -92,7 +92,10 @@ func MutableSourceFromScratch() (*MutableSource, error) {
 		},
 		extraBlobs: make(map[string][]byte),
 		cfg:        config,
-		mfst:       &manifest.Schema2{},
+		mfst: &manifest.Schema2{
+			SchemaVersion: 2,
+			MediaType:     manifest.DockerV2Schema2MediaType,
+		},
 	}
 	return ms, nil
 }


### PR DESCRIPTION
We need to add the manifest type to scratch images so the retagger will work w/ kaniko