### PR TITLE
rpm differ: use entrypoint for execution

### DIFF
--- a/differs/rpm_diff.go
+++ b/differs/rpm_diff.go
@@ -154,8 +154,8 @@ func rpmDataFromContainer(image pkgutil.Image) (map[string]util.PackageInfo, err
 	}
 
 	contConf := godocker.Config{
-		Cmd:   []string{"rpm", "--nodigest", "--nosignature", "-qa", "--qf", "%{NAME}\t%{VERSION}\t%{SIZE}\n"},
-		Image: imageName,
+		Entrypoint: []string{"rpm", "--nodigest", "--nosignature", "-qa", "--qf", "%{NAME}\t%{VERSION}\t%{SIZE}\n"},
+		Image:      imageName,
 	}
 
 	hostConf := godocker.HostConfig{


### PR DESCRIPTION
Use the container's entrypoint instead of specifying the RPM query in
the cmd field.  Otherwise, the rpm analysis of images with a specified
entrypoint will fail, as such is executed prior to any command.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>

Cc: @mssola