### PR TITLE
Check if symlinks are the same during file system diffing

### DIFF
--- a/pkg/util/fs_utils.go
+++ b/pkg/util/fs_utils.go
@@ -130,6 +130,18 @@ func CreateDirectoryEntries(root string, entryNames []string) (entries []Directo
 	return entries
 }
 
+func CheckSameSymlink(f1name, f2name string) (bool, error) {
+	link1, err := os.Readlink(f1name)
+	if err != nil {
+		return false, err
+	}
+	link2, err := os.Readlink(f2name)
+	if err != nil {
+		return false, err
+	}
+	return (link1 == link2), nil
+}
+
 func CheckSameFile(f1name, f2name string) (bool, error) {
 	// Check first if files differ in size and immediately return
 	f1stat, err := os.Stat(f1name)


### PR DESCRIPTION
We were getting a bunch of these errors when diffing images in kaniko integration tests:

```time="2018-05-09T13:52:58-07:00" level=error msg="Error checking directory entry /etc/systemd/system/timers.target.wants/apt-daily.timer: stat /tmpfs/tmp/gcr.iokaniko-testdocker-dockerfilesdockerfile_test_addlatest601063962/etc/systemd/system/timers.target.wants/apt-daily.timer: no such file or directory\n"```

All the files were actually symlinks, so I changed `os.Stat` to `os.Lstat` and added a check to see if symlinks are the same when diffing the file system