### PR TITLE
Do not overwrite the loaded tarball image

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,9 +141,7 @@ func getImageForName(imageName string) (pkgutil.Image, error) {
 		}
 		elapsed := time.Now().Sub(start)
 		logrus.Infof("retrieving image from tar took %f seconds", elapsed.Seconds())
-	}
-
-	if strings.HasPrefix(imageName, DaemonPrefix) {
+	} else if strings.HasPrefix(imageName, DaemonPrefix) {
 		// remove the daemon prefix
 		imageName = strings.Replace(imageName, DaemonPrefix, "", -1)
 


### PR DESCRIPTION
This commit makes sure that if the provided argument is a local
tarfile, the loaded image into the `img` varible does not get
overwritten by trying to fetch something from a remote registry.

From what I understand the `img` variable initialized in https://github.com/GoogleContainerTools/container-diff/blob/0ffd08ab6b87fa4997c0f6a62dfb1371dea02ad9/cmd/root.go#L132 is always ignored by assuming the given argument is a remote reference.