### PR TITLE
Reuse cached filesystems for layers

### DIFF
--- a/pkg/util/image_utils.go
+++ b/pkg/util/image_utils.go
@@ -77,6 +77,14 @@ func SortMap(m map[string]string) string {
 
 // GetFileSystemForLayer unpacks a layer to local disk
 func GetFileSystemForLayer(layer v1.Layer, root string, whitelist []string) error {
+	empty, err := DirIsEmpty(root)
+	if err != nil {
+		return err
+	}
+	if !empty {
+		logrus.Infof("using cached filesystem in %s", root)
+		return nil
+	}
 	contents, err := layer.Uncompressed()
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit applies the same criteria for reusing extracted layer
filesystems than the one used for the whole image extracted filesystem

Signed-off-by: David Cassany <dcassany@suse.de>