### PR TITLE
Layered analysis for single version packages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,8 @@ const (
 	RemotePrefix = "remote://"
 )
 
+var layerAnalyzers = [...]string{"layer", "aptlayer"}
+
 var RootCmd = &cobra.Command{
 	Use:   "container-diff",
 	Short: "container-diff is a tool for analyzing and comparing container images",
@@ -268,8 +270,10 @@ func getExtractPathForName(name string) (string, error) {
 
 func includeLayers() bool {
 	for _, t := range types {
-		if strings.Contains(t, "layer") {
-			return true
+		for _, a := range layerAnalyzers {
+			if t == a {
+				return true
+			}
 		}
 	}
 	return false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -268,7 +268,7 @@ func getExtractPathForName(name string) (string, error) {
 
 func includeLayers() bool {
 	for _, t := range types {
-		if t == "layer" {
+		if strings.Contains(t, "layer") {
 			return true
 		}
 	}

--- a/differs/differs.go
+++ b/differs/differs.go
@@ -47,6 +47,7 @@ var Analyzers = map[string]Analyzer{
 	"file":     FileAnalyzer{},
 	"layer":    FileLayerAnalyzer{},
 	"apt":      AptAnalyzer{},
+	"aptlayer": AptLayerAnalyzer{},
 	"rpm":      RPMAnalyzer{},
 	"pip":      PipAnalyzer{},
 	"node":     NodeAnalyzer{},

--- a/differs/package_differs.go
+++ b/differs/package_differs.go
@@ -21,6 +21,7 @@ import (
 
 	pkgutil "github.com/GoogleContainerTools/container-diff/pkg/util"
 	"github.com/GoogleContainerTools/container-diff/util"
+	"github.com/sirupsen/logrus"
 )
 
 type MultiVersionPackageAnalyzer interface {
@@ -30,6 +31,11 @@ type MultiVersionPackageAnalyzer interface {
 
 type SingleVersionPackageAnalyzer interface {
 	getPackages(image pkgutil.Image) (map[string]util.PackageInfo, error)
+	Name() string
+}
+
+type SingleVersionPackageLayerAnalyzer interface {
+	getPackages(image pkgutil.Image) ([]map[string]util.PackageInfo, error)
 	Name() string
 }
 
@@ -71,6 +77,43 @@ func singleVersionDiff(image1, image2 pkgutil.Image, differ SingleVersionPackage
 	}, nil
 }
 
+// singleVersionLayerDiff diffs the packages of each image layer by layer
+func singleVersionLayerDiff(image1, image2 pkgutil.Image, differ SingleVersionPackageLayerAnalyzer) (*util.SingleVersionPackageLayerDiffResult, error) {
+	pack1, err := differ.getPackages(image1)
+	if err != nil {
+		return &util.SingleVersionPackageLayerDiffResult{}, err
+	}
+	pack2, err := differ.getPackages(image2)
+	if err != nil {
+		return &util.SingleVersionPackageLayerDiffResult{}, err
+	}
+	var pkgDiffs []util.PackageDiff
+
+	// Go through each layer for image1
+	for i := range pack1 {
+		if i >= len(pack2) {
+			// Skip diff when there is no layer to compare with in image2
+			continue
+		}
+
+		pkgDiff := util.GetMapDiff(pack1[i], pack2[i])
+		pkgDiffs = append(pkgDiffs, pkgDiff)
+	}
+
+	if len(image1.Layers) != len(image2.Layers) {
+		logrus.Infof("%s and %s have different number of layers, please consider using container-diff analyze to view the contents of each image in each layer", image1.Source, image2.Source)
+	}
+
+	return &util.SingleVersionPackageLayerDiffResult{
+		Image1:   image1.Source,
+		Image2:   image2.Source,
+		DiffType: strings.TrimSuffix(differ.Name(), "Analyzer"),
+		Diff: util.PackageLayerDiff{
+			PackageDiffs: pkgDiffs,
+		},
+	}, nil
+}
+
 func multiVersionAnalysis(image pkgutil.Image, analyzer MultiVersionPackageAnalyzer) (*util.MultiVersionPackageAnalyzeResult, error) {
 	pack, err := analyzer.getPackages(image)
 	if err != nil {
@@ -97,4 +140,40 @@ func singleVersionAnalysis(image pkgutil.Image, analyzer SingleVersionPackageAna
 		Analysis:    pack,
 	}
 	return &analysis, nil
+}
+
+// singleVersionLayerAnalysis returns the packages included, deleted or
+// updated in each layer
+func singleVersionLayerAnalysis(image pkgutil.Image, analyzer SingleVersionPackageLayerAnalyzer) (*util.SingleVersionPackageLayerAnalyzeResult, error) {
+	pack, err := analyzer.getPackages(image)
+	if err != nil {
+		return &util.SingleVersionPackageLayerAnalyzeResult{}, err
+	}
+	var pkgDiffs []util.PackageDiff
+
+	// Each layer with modified packages includes a complete list of packages
+	// in its package database. Thus we diff the current layer with the
+	// previous one. Not all layers may include differences in packages, those
+	// are omitted.
+	preInd := -1
+	for i := range pack {
+		var pkgDiff util.PackageDiff
+		if preInd < 0 && len(pack[i]) > 0 {
+			pkgDiff = util.GetMapDiff(make(map[string]util.PackageInfo), pack[i])
+			preInd = i
+		} else if preInd >= 0 && len(pack[i]) > 0 {
+			pkgDiff = util.GetMapDiff(pack[preInd], pack[i])
+			preInd = i
+		}
+
+		pkgDiffs = append(pkgDiffs, pkgDiff)
+	}
+
+	return &util.SingleVersionPackageLayerAnalyzeResult{
+		Image:       image.Source,
+		AnalyzeType: strings.TrimSuffix(analyzer.Name(), "Analyzer"),
+		Analysis: util.PackageLayerDiff{
+			PackageDiffs: pkgDiffs,
+		},
+	}, nil
 }

--- a/util/format_utils.go
+++ b/util/format_utils.go
@@ -30,7 +30,6 @@ import (
 
 var templates = map[string]string{
 	"SingleVersionPackageDiff":         SingleVersionDiffOutput,
-	"SingleVersionPackageLayerDiff":    SingleVersionLayerDiffOutput,
 	"MultiVersionPackageDiff":          MultiVersionDiffOutput,
 	"HistDiff":                         HistoryDiffOutput,
 	"MetadataDiff":                     MetadataDiffOutput,

--- a/util/format_utils.go
+++ b/util/format_utils.go
@@ -29,18 +29,20 @@ import (
 )
 
 var templates = map[string]string{
-	"SingleVersionPackageDiff":    SingleVersionDiffOutput,
-	"MultiVersionPackageDiff":     MultiVersionDiffOutput,
-	"HistDiff":                    HistoryDiffOutput,
-	"MetadataDiff":                MetadataDiffOutput,
-	"DirDiff":                     FSDiffOutput,
-	"MultipleDirDiff":             FSLayerDiffOutput,
-	"FilenameDiff":                FilenameDiffOutput,
-	"ListAnalyze":                 ListAnalysisOutput,
-	"FileAnalyze":                 FileAnalysisOutput,
-	"FileLayerAnalyze":            FileLayerAnalysisOutput,
-	"MultiVersionPackageAnalyze":  MultiVersionPackageOutput,
-	"SingleVersionPackageAnalyze": SingleVersionPackageOutput,
+	"SingleVersionPackageDiff":         SingleVersionDiffOutput,
+	"SingleVersionPackageLayerDiff":    SingleVersionLayerDiffOutput,
+	"MultiVersionPackageDiff":          MultiVersionDiffOutput,
+	"HistDiff":                         HistoryDiffOutput,
+	"MetadataDiff":                     MetadataDiffOutput,
+	"DirDiff":                          FSDiffOutput,
+	"MultipleDirDiff":                  FSLayerDiffOutput,
+	"FilenameDiff":                     FilenameDiffOutput,
+	"ListAnalyze":                      ListAnalysisOutput,
+	"FileAnalyze":                      FileAnalysisOutput,
+	"FileLayerAnalyze":                 FileLayerAnalysisOutput,
+	"MultiVersionPackageAnalyze":       MultiVersionPackageOutput,
+	"SingleVersionPackageAnalyze":      SingleVersionPackageOutput,
+	"SingleVersionPackageLayerAnalyze": SingleVersionPackageLayerOutput,
 }
 
 func JSONify(diff interface{}) error {

--- a/util/package_diff_utils.go
+++ b/util/package_diff_utils.go
@@ -46,6 +46,12 @@ type PackageDiff struct {
 	InfoDiff  []Info
 }
 
+// PackageLayerDiff stores the difference information between two images
+// layer by layer in PackageDiff array
+type PackageLayerDiff struct {
+	PackageDiffs []PackageDiff
+}
+
 // Info stores the information for one package in two different images.
 type Info struct {
 	Package string

--- a/util/template_utils.go
+++ b/util/template_utils.go
@@ -61,22 +61,6 @@ PACKAGE	IMAGE1 ({{.Image1}})	IMAGE2 ({{.Image2}}){{range .Diff.InfoDiff}}{{"\n"}
 {{end}}
 `
 
-const SingleVersionLayerDiffOutput = `
------{{.DiffType}}-----
-{{range $index, $diff := .Diff}}
-Diff for Layer {{$index}}: {{if not (or (or $diff.Packages1 $diff.Packages2) $diff.InfoDiff)}} No differences {{else}}
-Packages found only in {{$.Image1}}:{{if not $diff.Packages1}} None{{else}}
-NAME	VERSION	SIZE{{range $diff.Packages1}}{{"\n"}}{{print "-"}}{{.Name}}	{{.Version}}	{{.Size}}{{end}}{{end}}
-
-Packages found only in {{$.Image2}}:{{if not $diff.Packages2}} None{{else}}
-NAME	VERSION	SIZE{{range $diff.Packages2}}{{"\n"}}{{print "-"}}{{.Name}}	{{.Version}}	{{.Size}}{{end}}{{end}}
-
-Version differences:{{if not $diff.InfoDiff}} None{{else}}
-PACKAGE	IMAGE1 ({{$.Image1}})	IMAGE2 ({{$.Image2}}){{range $diff.InfoDiff}}{{"\n"}}{{print "-"}}{{.Package}}	{{.Info1.Version}}, {{.Info1.Size}}	{{.Info2.Version}}, {{.Info2.Size}}{{end}}
-{{end}}{{end}}
-{{end}}
-`
-
 const MultiVersionDiffOutput = `
 -----{{.DiffType}}-----
 

--- a/util/template_utils.go
+++ b/util/template_utils.go
@@ -61,6 +61,22 @@ PACKAGE	IMAGE1 ({{.Image1}})	IMAGE2 ({{.Image2}}){{range .Diff.InfoDiff}}{{"\n"}
 {{end}}
 `
 
+const SingleVersionLayerDiffOutput = `
+-----{{.DiffType}}-----
+{{range $index, $diff := .Diff}}
+Diff for Layer {{$index}}: {{if not (or (or $diff.Packages1 $diff.Packages2) $diff.InfoDiff)}} No differences {{else}}
+Packages found only in {{$.Image1}}:{{if not $diff.Packages1}} None{{else}}
+NAME	VERSION	SIZE{{range $diff.Packages1}}{{"\n"}}{{print "-"}}{{.Name}}	{{.Version}}	{{.Size}}{{end}}{{end}}
+
+Packages found only in {{$.Image2}}:{{if not $diff.Packages2}} None{{else}}
+NAME	VERSION	SIZE{{range $diff.Packages2}}{{"\n"}}{{print "-"}}{{.Name}}	{{.Version}}	{{.Size}}{{end}}{{end}}
+
+Version differences:{{if not $diff.InfoDiff}} None{{else}}
+PACKAGE	IMAGE1 ({{$.Image1}})	IMAGE2 ({{$.Image2}}){{range $diff.InfoDiff}}{{"\n"}}{{print "-"}}{{.Package}}	{{.Info1.Version}}, {{.Info1.Size}}	{{.Info2.Version}}, {{.Info2.Size}}{{end}}
+{{end}}{{end}}
+{{end}}
+`
+
 const MultiVersionDiffOutput = `
 -----{{.DiffType}}-----
 
@@ -137,5 +153,21 @@ const SingleVersionPackageOutput = `
 
 Packages found in {{.Image}}:{{if not .Analysis}} None{{else}}
 NAME	VERSION	SIZE{{range .Analysis}}{{"\n"}}{{print "-"}}{{.Name}}	{{.Version}}	{{.Size}}{{end}}
+{{end}}
+`
+
+const SingleVersionPackageLayerOutput = `
+-----{{.AnalyzeType}}-----
+{{range $index, $analysis := .Analysis}}
+For Layer {{$index}}:{{if not (or (or $analysis.Packages1 $analysis.Packages2) $analysis.InfoDiff)}} No package changes {{else}}
+{{if ne $index 0}}Deleted packages from previous layers:{{if not $analysis.Packages1}} None{{else}}
+NAME	VERSION	SIZE{{range $analysis.Packages1}}{{"\n"}}{{print "-"}}{{.Name}}	{{.Version}}	{{.Size}}{{end}}{{end}}
+
+{{end}}Packages added in this layer:{{if not $analysis.Packages2}} None{{else}}
+NAME	VERSION	SIZE{{range $analysis.Packages2}}{{"\n"}}{{print "-"}}{{.Name}}	{{.Version}}	{{.Size}}{{end}}{{end}}
+{{if ne $index 0}}
+Version differences:{{if not $analysis.InfoDiff}} None{{else}}
+PACKAGE	PREV_LAYER	CURRENT_LAYER {{range $analysis.InfoDiff}}{{"\n"}}{{print "-"}}{{.Package}}	{{.Info1.Version}}, {{.Info1.Size}}	{{.Info2.Version}}, {{.Info2.Size}}{{end}}
+{{end}}{{end}}{{end}}
 {{end}}
 `


### PR DESCRIPTION
This PR implements the interfaces to perform package differs on layers. For diff command it compares the packages of each image on each layer, one by one. For analyze command it diffs the packages of each layer within the previous one (layers without packages changes are omitted).

Fixes #246