### PR TITLE
Handle error gracefully when we can't retrieve an image

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -17,13 +17,13 @@ limitations under the License.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/GoogleContainerTools/container-diff/cmd/util/output"
 	"github.com/GoogleContainerTools/container-diff/differs"
 	pkgutil "github.com/GoogleContainerTools/container-diff/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -56,19 +56,19 @@ func checkAnalyzeArgNum(args []string) error {
 func analyzeImage(imageName string, analyzerArgs []string) error {
 	analyzeTypes, err := differs.GetAnalyzers(analyzerArgs)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting analyzers")
 	}
 
 	image, err := getImageForName(imageName)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error retrieving image %s", imageName)
 	}
 
 	if noCache && !save {
 		defer pkgutil.CleanupImage(image)
 	}
 	if err != nil {
-		return fmt.Errorf("Error processing image: %s", err)
+		return fmt.Errorf("error processing image: %s", err)
 	}
 
 	req := differs.SingleRequest{
@@ -76,7 +76,7 @@ func analyzeImage(imageName string, analyzerArgs []string) error {
 		AnalyzeTypes: analyzeTypes}
 	analyses, err := req.GetAnalysis()
 	if err != nil {
-		return fmt.Errorf("Error performing image analysis: %s", err)
+		return fmt.Errorf("error performing image analysis: %s", err)
 	}
 
 	logrus.Info("retrieving analyses")

--- a/cmd/analyze_test.go
+++ b/cmd/analyze_test.go
@@ -29,11 +29,11 @@ var analyzeArgNumTests = []testpair{
 func TestAnalyzeArgNum(t *testing.T) {
 	for _, test := range analyzeArgNumTests {
 		err := checkAnalyzeArgNum(test.input)
-		if (err == nil) != test.expected_output {
-			if test.expected_output {
-				t.Errorf("Got unexpected error: %s", err)
-			} else {
+		if (err == nil) != test.shouldError {
+			if test.shouldError {
 				t.Errorf("Expected error but got none")
+			} else {
+				t.Errorf("Got unexpected error: %s", err)
 			}
 		}
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -70,6 +70,7 @@ func checkFilenameFlag(_ []string) error {
 	return errors.New("please include --types=file with the --filename flag")
 }
 
+// processImage is a concurrency-friendly wrapper around getImageForName
 func processImage(imageName string, imageMap map[string]*pkgutil.Image, wg *sync.WaitGroup, errChan chan<- error) {
 	defer wg.Done()
 	image, err := getImageForName(imageName)

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -21,21 +21,46 @@ import (
 )
 
 var diffArgNumTests = []testpair{
-	{[]string{}, false},
-	{[]string{"one"}, false},
-	{[]string{"one", "two"}, true},
-	{[]string{"one", "two", "three"}, false},
+	{[]string{}, true},
+	{[]string{"one"}, true},
+	{[]string{"one", "two"}, false},
+	{[]string{"one", "two", "three"}, true},
 }
 
 func TestDiffArgNum(t *testing.T) {
 	for _, test := range diffArgNumTests {
 		err := checkDiffArgNum(test.input)
-		if (err == nil) != test.expected_output {
-			if test.expected_output {
-				t.Errorf("Got unexpected error: %s", err)
-			} else {
-				t.Errorf("Expected error but got none")
-			}
+		checkError(t, err, test.shouldError)
+	}
+}
+
+type imageDiff struct {
+	image1      string
+	image2      string
+	shouldError bool
+}
+
+var imageDiffs = []imageDiff{
+	{"", "", true},
+	{"gcr.io/google-appengine/python", "gcr.io/google-appengine/debian9", false},
+	{"gcr.io/google-appengine/python", "cats", true},
+}
+
+func TestDiffImages(t *testing.T) {
+	for _, test := range imageDiffs {
+		err := diffImages(test.image1, test.image2, []string{"apt"})
+		checkError(t, err, test.shouldError)
+		err = diffImages(test.image1, test.image2, []string{"metadata"})
+		checkError(t, err, test.shouldError)
+	}
+}
+
+func checkError(t *testing.T, err error, shouldError bool) {
+	if (err == nil) == shouldError {
+		if shouldError {
+			t.Errorf("expected error but got none")
+		} else {
+			t.Errorf("got unexpected error: %s", err)
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,6 +132,9 @@ func checkIfValidAnalyzer(_ []string) error {
 	return nil
 }
 
+// getImageForName infers the source of an image and retrieves a v1.Image reference to it.
+// Once a reference is obtained, it attempts to unpack the v1.Image's reader's contents
+// into a temp directory on the local filesystem.
 func getImageForName(imageName string) (pkgutil.Image, error) {
 	logrus.Infof("retrieving image: %s", imageName)
 	var img v1.Image

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/GoogleContainerTools/container-diff/util"
 	"github.com/google/go-containerregistry/pkg/v1"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -139,17 +140,17 @@ func getImageForName(imageName string) (pkgutil.Image, error) {
 		start := time.Now()
 		img, err = tarball.ImageFromPath(imageName, nil)
 		if err != nil {
-			return pkgutil.Image{}, err
+			return pkgutil.Image{}, errors.Wrap(err, "retrieving tar from path")
 		}
 		elapsed := time.Now().Sub(start)
-		logrus.Infof("retrieving image from tar took %f seconds", elapsed.Seconds())
+		logrus.Infof("retrieving image ref from tar took %f seconds", elapsed.Seconds())
 	} else if strings.HasPrefix(imageName, DaemonPrefix) {
 		// remove the daemon prefix
 		imageName = strings.Replace(imageName, DaemonPrefix, "", -1)
 
 		ref, err := name.ParseReference(imageName, name.WeakValidation)
 		if err != nil {
-			return pkgutil.Image{}, err
+			return pkgutil.Image{}, errors.Wrap(err, "parsing image reference")
 		}
 
 		start := time.Now()
@@ -158,28 +159,28 @@ func getImageForName(imageName string) (pkgutil.Image, error) {
 			Buffer: true,
 		})
 		if err != nil {
-			return pkgutil.Image{}, err
+			return pkgutil.Image{}, errors.Wrap(err, "retrieving image from daemon")
 		}
 		elapsed := time.Now().Sub(start)
-		logrus.Infof("retrieving image from daemon took %f seconds", elapsed.Seconds())
+		logrus.Infof("retrieving local image ref took %f seconds", elapsed.Seconds())
 	} else {
 		// either has remote prefix or has no prefix, in which case we force remote
 		imageName = strings.Replace(imageName, RemotePrefix, "", -1)
 		ref, err := name.ParseReference(imageName, name.WeakValidation)
 		if err != nil {
-			return pkgutil.Image{}, err
+			return pkgutil.Image{}, errors.Wrap(err, "parsing image reference")
 		}
 		auth, err := authn.DefaultKeychain.Resolve(ref.Context().Registry)
 		if err != nil {
-			return pkgutil.Image{}, err
+			return pkgutil.Image{}, errors.Wrap(err, "resolving auth")
 		}
 		start := time.Now()
 		img, err = remote.Image(ref, auth, http.DefaultTransport)
 		if err != nil {
-			return pkgutil.Image{}, err
+			return pkgutil.Image{}, errors.Wrap(err, "retrieving remote image")
 		}
 		elapsed := time.Now().Sub(start)
-		logrus.Infof("retrieving remote image took %f seconds", elapsed.Seconds())
+		logrus.Infof("retrieving remote image ref took %f seconds", elapsed.Seconds())
 	}
 
 	// create tempdir and extract fs into it
@@ -188,7 +189,7 @@ func getImageForName(imageName string) (pkgutil.Image, error) {
 		start := time.Now()
 		imgLayers, err := img.Layers()
 		if err != nil {
-			return pkgutil.Image{}, err
+			return pkgutil.Image{}, errors.Wrap(err, "getting image layers")
 		}
 		for _, layer := range imgLayers {
 			layerStart := time.Now()
@@ -197,12 +198,12 @@ func getImageForName(imageName string) (pkgutil.Image, error) {
 			if err != nil {
 				return pkgutil.Image{
 					Layers: layers,
-				}, err
+				}, errors.Wrap(err, "getting extract path for layer")
 			}
 			if err := pkgutil.GetFileSystemForLayer(layer, path, nil); err != nil {
 				return pkgutil.Image{
 					Layers: layers,
-				}, err
+				}, errors.Wrap(err, "getting filesystem for layer")
 			}
 			layers = append(layers, pkgutil.Layer{
 				FSPath: path,
@@ -215,12 +216,15 @@ func getImageForName(imageName string) (pkgutil.Image, error) {
 	}
 
 	path, err := getExtractPathForImage(imageName, img)
+	if err != nil {
+		return pkgutil.Image{}, err
+	}
 	// extract fs into provided dir
 	if err := pkgutil.GetFileSystemForImage(img, path, nil); err != nil {
 		return pkgutil.Image{
 			FSPath: path,
 			Layers: layers,
-		}, err
+		}, errors.Wrap(err, "getting filesystem for image")
 	}
 	return pkgutil.Image{
 		Image:  img,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -17,6 +17,6 @@ limitations under the License.
 package cmd
 
 type testpair struct {
-	input           []string
-	expected_output bool
+	input       []string
+	shouldError bool
 }

--- a/differs/differs.go
+++ b/differs/differs.go
@@ -63,13 +63,13 @@ func (req DiffRequest) GetDiff() (map[string]util.Result, error) {
 		if diff, err := differ.Diff(img1, img2); err == nil {
 			results[differ.Name()] = diff
 		} else {
-			logrus.Errorf("Error getting diff with %s: %s", differ.Name(), err)
+			logrus.Errorf("error getting diff with %s: %s", differ.Name(), err)
 		}
 	}
 
 	var err error
 	if len(results) == 0 {
-		err = fmt.Errorf("Could not perform diff on %v and %v", img1, img2)
+		err = fmt.Errorf("could not perform diff on %v and %v", img1, img2)
 	} else {
 		err = nil
 	}
@@ -87,13 +87,13 @@ func (req SingleRequest) GetAnalysis() (map[string]util.Result, error) {
 		if analysis, err := analyzer.Analyze(img); err == nil {
 			results[analyzeName] = analysis
 		} else {
-			logrus.Errorf("Error getting analysis with %s: %s", analyzeName, err)
+			logrus.Errorf("error getting analysis with %s: %s", analyzeName, err)
 		}
 	}
 
 	var err error
 	if len(results) == 0 {
-		err = fmt.Errorf("Could not perform analysis on %v", img)
+		err = fmt.Errorf("could not perform analysis on %v", img)
 	} else {
 		err = nil
 	}
@@ -107,11 +107,11 @@ func GetAnalyzers(analyzeNames []string) ([]Analyzer, error) {
 		if a, exists := Analyzers[name]; exists {
 			analyzeFuncs = append(analyzeFuncs, a)
 		} else {
-			return nil, fmt.Errorf("Unknown analyzer/differ specified: %s", name)
+			return nil, fmt.Errorf("unknown analyzer/differ specified: %s", name)
 		}
 	}
 	if len(analyzeFuncs) == 0 {
-		return nil, fmt.Errorf("No known analyzers/differs specified")
+		return nil, fmt.Errorf("no known analyzers/differs specified")
 	}
 	return analyzeFuncs, nil
 }


### PR DESCRIPTION
This fixes the error handling for processing images before we do the diff or analysis. Errors are propagated back through a channel to the main loop, which will only execute the diff/analysis if we didn't receive any errors back from the image processing. Error handling also happens in the main loop now, so we'll get consistent results across diff types.

This also changes a bunch of error messages to add some more context when we do receive an error.

```
➜ ./out/container-diff diff dogs gcr.io/google-appengine/python:latest
2018/07/26 12:27:12 No matching credentials found for index.docker.io, falling back on anonymous
ERRO[0001] error retrieving image dogs: UNAUTHORIZED: "authentication required" 
➜ ./out/container-diff analyze dogs                                   
2018/07/26 12:27:16 No matching credentials found for index.docker.io, falling back on anonymous
ERRO[0000] error retrieving image dogs: UNAUTHORIZED: "authentication required"
```

Fixes #250 