### PR TITLE
Add rpmlayer differ

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ const (
 	RemotePrefix = "remote://"
 )
 
-var layerAnalyzers = [...]string{"layer", "aptlayer"}
+var layerAnalyzers = [...]string{"layer", "aptlayer", "rpmlayer"}
 
 var RootCmd = &cobra.Command{
 	Use:   "container-diff",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,8 +59,6 @@ const (
 	RemotePrefix = "remote://"
 )
 
-var layerAnalyzers = [...]string{"layer", "aptlayer", "rpmlayer"}
-
 var RootCmd = &cobra.Command{
 	Use:   "container-diff",
 	Short: "container-diff is a tool for analyzing and comparing container images",
@@ -270,7 +268,7 @@ func getExtractPathForName(name string) (string, error) {
 
 func includeLayers() bool {
 	for _, t := range types {
-		for _, a := range layerAnalyzers {
+		for _, a := range differs.LayerAnalyzers {
 			if t == a {
 				return true
 			}

--- a/differs/differs.go
+++ b/differs/differs.go
@@ -49,6 +49,7 @@ var Analyzers = map[string]Analyzer{
 	"apt":      AptAnalyzer{},
 	"aptlayer": AptLayerAnalyzer{},
 	"rpm":      RPMAnalyzer{},
+	"rpmlayer": RPMLayerAnalyzer{},
 	"pip":      PipAnalyzer{},
 	"node":     NodeAnalyzer{},
 }

--- a/differs/differs.go
+++ b/differs/differs.go
@@ -24,6 +24,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const historyAnalyzer = "history"
+const metadataAnalyzer = "metadata"
+const fileAnalyzer = "file"
+const layerAnalyzer = "layer"
+const aptAnalyzer = "apt"
+const aptLayerAnalyzer = "aptlayer"
+const rpmAnalyzer = "rpm"
+const rpmLayerAnalyzer = "rpmlayer"
+const pipAnalyzer = "pip"
+const nodeAnalyzer = "node"
+
 type DiffRequest struct {
 	Image1    pkgutil.Image
 	Image2    pkgutil.Image
@@ -42,17 +53,19 @@ type Analyzer interface {
 }
 
 var Analyzers = map[string]Analyzer{
-	"history":  HistoryAnalyzer{},
-	"metadata": MetadataAnalyzer{},
-	"file":     FileAnalyzer{},
-	"layer":    FileLayerAnalyzer{},
-	"apt":      AptAnalyzer{},
-	"aptlayer": AptLayerAnalyzer{},
-	"rpm":      RPMAnalyzer{},
-	"rpmlayer": RPMLayerAnalyzer{},
-	"pip":      PipAnalyzer{},
-	"node":     NodeAnalyzer{},
+	historyAnalyzer:  HistoryAnalyzer{},
+	metadataAnalyzer: MetadataAnalyzer{},
+	fileAnalyzer:     FileAnalyzer{},
+	layerAnalyzer:    FileLayerAnalyzer{},
+	aptAnalyzer:      AptAnalyzer{},
+	aptLayerAnalyzer: AptLayerAnalyzer{},
+	rpmAnalyzer:      RPMAnalyzer{},
+	rpmLayerAnalyzer: RPMLayerAnalyzer{},
+	pipAnalyzer:      PipAnalyzer{},
+	nodeAnalyzer:     NodeAnalyzer{},
 }
+
+var LayerAnalyzers = [...]string{layerAnalyzer, aptLayerAnalyzer, rpmLayerAnalyzer}
 
 func (req DiffRequest) GetDiff() (map[string]util.Result, error) {
 	img1 := req.Image1


### PR DESCRIPTION
This commit adds the rpmlayer differ that allows to perform analysis
at rpm package level on each layer. Lists new, deleted and modified
(different version) packages on each layer.

Signed-off-by: David Cassany <dcassany@suse.de>