### PR TITLE
Change the default analysis type from apt to size

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ container-diff analyze <img> --type=apt --type=node  [Apt and Node]
 # --type=<analyzer1> --type=<analyzer2> --type=<analyzer3>,...
 ```
 
-By default, with no `--type` flag specified, container-diff will run Apt package analysis.
+By default, with no `--type` flag specified, container-diff will run image size analysis.
 
 To use container-diff to perform a diff analysis on two images, you need two Docker images (in the form of an ID, tarball, or URL from a repo). Once you have those images, you can run any of the following differs:
 ```shell

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,7 +120,7 @@ func validateArgs(args []string, validatefxns ...validatefxn) error {
 
 func checkIfValidAnalyzer(_ []string) error {
 	if len(types) == 0 {
-		types = []string{"apt"}
+		types = []string{"size"}
 	}
 	for _, name := range types {
 		if _, exists := differs.Analyzers[name]; !exists {


### PR DESCRIPTION
- Changes the default type for both `analyze` and `diff` to `--type=size`

Fixes https://github.com/GoogleContainerTools/container-diff/issues/227