### PR TITLE
Move all image processing logic into utils, and expose publically

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -59,7 +59,7 @@ func analyzeImage(imageName string, analyzerArgs []string) error {
 		return errors.Wrap(err, "getting analyzers")
 	}
 
-	image, err := getImageForName(imageName)
+	image, err := getImage(imageName)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving image %s", imageName)
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -73,7 +73,7 @@ func checkFilenameFlag(_ []string) error {
 // processImage is a concurrency-friendly wrapper around getImageForName
 func processImage(imageName string, imageMap map[string]*pkgutil.Image, wg *sync.WaitGroup, errChan chan<- error) {
 	defer wg.Done()
-	image, err := getImageForName(imageName)
+	image, err := getImage(imageName)
 	if err != nil {
 		errChan <- fmt.Errorf("error retrieving image %s: %s", imageName, err)
 	}

--- a/pkg/util/image_utils.go
+++ b/pkg/util/image_utils.go
@@ -21,19 +21,33 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
 	"github.com/docker/docker/pkg/system"
-	"github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-const tagRegexStr = ".*:([^/]+$)"
+const (
+	daemonPrefix = "daemon://"
+	remotePrefix = "remote://"
+
+	tagRegexStr = ".*:([^/]+$)"
+)
 
 type Layer struct {
 	FSPath string
@@ -50,6 +64,155 @@ type Image struct {
 
 type ImageHistoryItem struct {
 	CreatedBy string `json:"created_by"`
+}
+
+// GetImageForName retrieves an image by name alone.
+// It does not return layer information, or respect caching.
+func GetImageForName(imageName string) (Image, error) {
+	return GetImage(imageName, false, "")
+}
+
+// GetImage infers the source of an image and retrieves a v1.Image reference to it.
+// Once a reference is obtained, it attempts to unpack the v1.Image's reader's contents
+// into a temp directory on the local filesystem.
+func GetImage(imageName string, includeLayers bool, cacheDir string) (Image, error) {
+	logrus.Infof("retrieving image: %s", imageName)
+	var img v1.Image
+	var err error
+	if IsTar(imageName) {
+		start := time.Now()
+		img, err = tarball.ImageFromPath(imageName, nil)
+		if err != nil {
+			return Image{}, errors.Wrap(err, "retrieving tar from path")
+		}
+		elapsed := time.Now().Sub(start)
+		logrus.Infof("retrieving image ref from tar took %f seconds", elapsed.Seconds())
+	} else if strings.HasPrefix(imageName, daemonPrefix) {
+		// remove the daemon prefix
+		imageName = strings.Replace(imageName, daemonPrefix, "", -1)
+
+		ref, err := name.ParseReference(imageName, name.WeakValidation)
+		if err != nil {
+			return Image{}, errors.Wrap(err, "parsing image reference")
+		}
+
+		start := time.Now()
+		// TODO(nkubala): specify gzip.NoCompression here when functional options are supported
+		img, err = daemon.Image(ref, daemon.WithBufferedOpener())
+		if err != nil {
+			return Image{}, errors.Wrap(err, "retrieving image from daemon")
+		}
+		elapsed := time.Now().Sub(start)
+		logrus.Infof("retrieving local image ref took %f seconds", elapsed.Seconds())
+	} else {
+		// either has remote prefix or has no prefix, in which case we force remote
+		imageName = strings.Replace(imageName, remotePrefix, "", -1)
+		ref, err := name.ParseReference(imageName, name.WeakValidation)
+		if err != nil {
+			return Image{}, errors.Wrap(err, "parsing image reference")
+		}
+		auth, err := authn.DefaultKeychain.Resolve(ref.Context().Registry)
+		if err != nil {
+			return Image{}, errors.Wrap(err, "resolving auth")
+		}
+		start := time.Now()
+		img, err = remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+		if err != nil {
+			return Image{}, errors.Wrap(err, "retrieving remote image")
+		}
+		elapsed := time.Now().Sub(start)
+		logrus.Infof("retrieving remote image ref took %f seconds", elapsed.Seconds())
+	}
+
+	// create tempdir and extract fs into it
+	var layers []Layer
+	if includeLayers {
+		start := time.Now()
+		imgLayers, err := img.Layers()
+		if err != nil {
+			return Image{}, errors.Wrap(err, "getting image layers")
+		}
+		for _, layer := range imgLayers {
+			layerStart := time.Now()
+			digest, err := layer.Digest()
+			path, err := getExtractPathForName(digest.String(), cacheDir)
+			if err != nil {
+				return Image{
+					Layers: layers,
+				}, errors.Wrap(err, "getting extract path for layer")
+			}
+			if err := GetFileSystemForLayer(layer, path, nil); err != nil {
+				return Image{
+					Layers: layers,
+				}, errors.Wrap(err, "getting filesystem for layer")
+			}
+			layers = append(layers, Layer{
+				FSPath: path,
+				Digest: digest,
+			})
+			elapsed := time.Now().Sub(layerStart)
+			logrus.Infof("time elapsed retrieving layer: %fs", elapsed.Seconds())
+		}
+		elapsed := time.Now().Sub(start)
+		logrus.Infof("time elapsed retrieving image layers: %fs", elapsed.Seconds())
+	}
+
+	imageDigest, err := getImageDigest(img)
+	if err != nil {
+		return Image{}, err
+	}
+	path, err := getExtractPathForName(RemoveTag(imageName)+"@"+imageDigest.String(), cacheDir)
+	if err != nil {
+		return Image{}, err
+	}
+	// extract fs into provided dir
+	if err := GetFileSystemForImage(img, path, nil); err != nil {
+		return Image{
+			FSPath: path,
+			Layers: layers,
+		}, errors.Wrap(err, "getting filesystem for image")
+	}
+	return Image{
+		Image:  img,
+		Source: imageName,
+		FSPath: path,
+		Digest: imageDigest,
+		Layers: layers,
+	}, nil
+}
+
+func getExtractPathForName(name string, cacheDir string) (string, error) {
+	path := cacheDir
+	var err error
+	if cacheDir != "" {
+		// if cachedir doesn't exist, create it
+		if _, err := os.Stat(cacheDir); err != nil && os.IsNotExist(err) {
+			err = os.MkdirAll(cacheDir, 0700)
+			if err != nil {
+				return "", err
+			}
+			logrus.Infof("caching filesystem at %s", cacheDir)
+		}
+	} else {
+		// otherwise, create tempdir
+		logrus.Infof("skipping caching")
+		path, err = ioutil.TempDir("", strings.Replace(name, "/", "", -1))
+		if err != nil {
+			return "", err
+		}
+	}
+	return path, nil
+}
+
+func getImageDigest(image v1.Image) (digest v1.Hash, err error) {
+	start := time.Now()
+	digest, err = image.Digest()
+	if err != nil {
+		return digest, err
+	}
+	elapsed := time.Now().Sub(start)
+	logrus.Infof("time elapsed retrieving image digest: %fs", elapsed.Seconds())
+	return digest, nil
 }
 
 func CleanupImage(image Image) {


### PR DESCRIPTION
This PR moves all image processing logic into `pkg/util`, since it didn't really have any business being in `cmd`. It also slightly refactors the function naming, and exposes `GetImage` so it can be used externally. This completes the replacement of the `Prepper` implementations done in https://github.com/GoogleContainerTools/container-diff/pull/229.