### PR TITLE
Split lines prior to diffing

### DIFF
--- a/util/diff_utils.go
+++ b/util/diff_utils.go
@@ -167,8 +167,8 @@ func DiffFile(image1, image2 *pkgutil.Image, filename string) (*FileNameDiff, er
 	}
 
 	//Carry on with diffing, make string array for difflib requirements
-	image1Contents := []string{string(*image1FileContents)}
-	image2Contents := []string{string(*image2FileContents)}
+	image1Contents := difflib.SplitLines(string(*image1FileContents))
+	image2Contents := difflib.SplitLines(string(*image2FileContents))
 
 	//Run diff
 	diff := difflib.UnifiedDiff{


### PR DESCRIPTION
Fixes #271 

```
$ out/container-diff diff --type=file --filename=/var/lib/dpkg/status.d/openjdk remote://gcr.io/distroless/java@sha256:b430543bea1d8326e767058bdab3a2482ea45f59d7af5c5c61334cd29ede88a1 remote://gcr.io/distroless/java@sha256:bb1c9179c2263733f235291998cb849d52fb730743125420cf4f97a362d6a6dd
[...]
-----Diff of /var/lib/dpkg/status.d/openjdk-----


--- gcr.io/distroless/java@sha256:b430543bea1d8326e767058bdab3a2482ea45f59d7af5c5c61334cd29ede88a1
+++ gcr.io/distroless/java@sha256:bb1c9179c2263733f235291998cb849d52fb730743125420cf4f97a362d6a6dd
@@ -3 +3 @@
-Version: 8u171-b11-1~deb9u1
+Version: 8u181-b13-1~deb9u1
@@ -6 +6 @@
-Installed-Size: 97311
+Installed-Size: 97352

```