### PR TITLE
Adding custom cache envar and command line argument

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,7 +151,7 @@ func getCacheDir(imageName string) (string, error) {
 	if cacheDir == "" {
 		dir, err := homedir.Dir()
 		if err != nil {
-                        return "", err
+			return "", err
 		} else {
 			cacheDir = dir
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,10 +141,8 @@ func getImage(imageName string) (pkgutil.Image, error) {
 }
 
 func getCacheDir(imageName string) (string, error) {
-
 	// First preference for cache is set at command line
 	if cacheDir == "" {
-
 		// second preference is environment
 		cacheDir = os.Getenv(containerDiffEnvCacheDir)
 	}
@@ -153,7 +151,7 @@ func getCacheDir(imageName string) (string, error) {
 	if cacheDir == "" {
 		dir, err := homedir.Dir()
 		if err != nil {
-			return "", err
+                        return "", errors.Wrap(err, "retrieving home dir")
 		} else {
 			cacheDir = dir
 		}
@@ -201,6 +199,6 @@ func addSharedFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&save, "save", "s", false, "Set this flag to save rather than remove the final image filesystems on exit.")
 	cmd.Flags().BoolVarP(&util.SortSize, "order", "o", false, "Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "n", false, "Set this to force retrieval of image filesystem on each run.")
-	cmd.Flags().StringVarP(&cacheDir, "cache", "c", "", "cache directory base to create .container-diff (default is $HOME).")
+	cmd.Flags().StringVarP(&cacheDir, "cache-dir", "c", "", "cache directory base to create .container-diff (default is $HOME).")
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ var save bool
 var types diffTypes
 var noCache bool
 
+var cacheDir string
 var LogLevel string
 var format string
 
@@ -129,7 +130,7 @@ func getImage(imageName string) (pkgutil.Image, error) {
 	var cachePath string
 	var err error
 	if !noCache {
-		cachePath, err = cacheDir(imageName)
+		cachePath, err = getCacheDir(imageName, cacheDir)
 		if err != nil {
 			return pkgutil.Image{}, err
 		}
@@ -137,7 +138,10 @@ func getImage(imageName string) (pkgutil.Image, error) {
 	return pkgutil.GetImage(imageName, includeLayers(), cachePath)
 }
 
-func cacheDir(imageName string) (string, error) {
+func getCacheDir(imageName string, cacheDir string) (string, error) {
+	// If the user has specified a custom cache directory
+        // TODO: write me
+        // else
 	dir, err := homedir.Dir()
 	if err != nil {
 		return "", err
@@ -185,4 +189,5 @@ func addSharedFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&save, "save", "s", false, "Set this flag to save rather than remove the final image filesystems on exit.")
 	cmd.Flags().BoolVarP(&util.SortSize, "order", "o", false, "Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "n", false, "Set this to force retrieval of image filesystem on each run.")
+        cmd.Flags().StringVar(&cacheDir, "cache", "", "cache directory base to create .container-diff (default is $HOME).")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -143,21 +143,21 @@ func getImage(imageName string) (pkgutil.Image, error) {
 func getCacheDir(imageName string) (string, error) {
 
 	// First preference for cache is set at command line
-        if cacheDir == "" {
+	if cacheDir == "" {
 
-                // second preference is environment
-                cacheDir = os.Getenv(containerDiffEnvCacheDir)
-        }
+		// second preference is environment
+		cacheDir = os.Getenv(containerDiffEnvCacheDir)
+	}
 
-        // Third preference (default) is set at $HOME
-        if cacheDir == "" {
-                dir, err := homedir.Dir()
-	        if err != nil {
-	                 return "", err
-                } else {
-                        cacheDir = dir
-                }
-        }
+	// Third preference (default) is set at $HOME
+	if cacheDir == "" {
+		dir, err := homedir.Dir()
+		if err != nil {
+			return "", err
+		} else {
+			cacheDir = dir
+		}
+	}
 	rootDir := filepath.Join(cacheDir, ".container-diff", "cache")
 	imageName = strings.Replace(imageName, string(os.PathSeparator), "", -1)
 	return filepath.Join(rootDir, filepath.Clean(imageName)), nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,7 +151,7 @@ func getCacheDir(imageName string) (string, error) {
 	if cacheDir == "" {
 		dir, err := homedir.Dir()
 		if err != nil {
-                        return "", errors.Wrap(err, "retrieving home dir")
+                        return "", err
 		} else {
 			cacheDir = dir
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -201,6 +201,6 @@ func addSharedFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&save, "save", "s", false, "Set this flag to save rather than remove the final image filesystems on exit.")
 	cmd.Flags().BoolVarP(&util.SortSize, "order", "o", false, "Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "n", false, "Set this to force retrieval of image filesystem on each run.")
-        cmd.Flags().StringVarP(&cacheDir, "cache", "c", "", "cache directory base to create .container-diff (default is $HOME).")
+	cmd.Flags().StringVarP(&cacheDir, "cache", "c", "", "cache directory base to create .container-diff (default is $HOME).")
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	pkgutil "github.com/GoogleContainerTools/container-diff/pkg/util"
 	"github.com/GoogleContainerTools/container-diff/util"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -151,7 +152,7 @@ func getCacheDir(imageName string) (string, error) {
 	if cacheDir == "" {
 		dir, err := homedir.Dir()
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "retrieving home dir")
 		} else {
 			cacheDir = dir
 		}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,3 +20,21 @@ type testpair struct {
 	input       []string
 	shouldError bool
 }
+
+func TestCacheDir(t *testing.T) {
+  tests := []struct{
+    name        string
+    cliFlag     string
+    envVar      string
+    expectedDir string
+  }{
+    // your tests cases here
+  }
+
+  for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+      // actual testing logic. probably set the env var, set the global flag based on the cliFlag, then
+      // call getCacheDir() and make sure the return value is equal to the expectedDir
+    }
+  }
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -84,7 +84,7 @@ func TestCacheDir(t *testing.T) {
 			// call getCacheDir and make sure return is equal to expected
 			actualDir, err := getCacheDir(tt.imageName)
 			if err != nil {
-				t.Errorf("%s\nerror getting cache dir", tt.name)
+				t.Errorf("Error getting cache dir %s: %s", tt.name, err.Error())
 			}
 
 			if path.Dir(actualDir) != tt.expectedDir {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -84,11 +84,11 @@ func TestCacheDir(t *testing.T) {
 			// call getCacheDir and make sure return is equal to expected
 			actualDir, err := getCacheDir(tt.imageName)
 			if err != nil {
-				t.Errorf("%s\nError getting cache dir", tt.name)
+				t.Errorf("%s\nerror getting cache dir", tt.name)
 			}
 
 			if path.Dir(actualDir) != tt.expectedDir {
-				t.Errorf("%s\nExpected: %v\nGot: %v", tt.name, tt.expectedDir, actualDir)
+				t.Errorf("%s\nexpected: %v\ngot: %v", tt.name, tt.expectedDir, actualDir)
 			}
 		},
 		)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,21 +20,3 @@ type testpair struct {
 	input       []string
 	shouldError bool
 }
-
-func TestCacheDir(t *testing.T) {
-  tests := []struct{
-    name        string
-    cliFlag     string
-    envVar      string
-    expectedDir string
-  }{
-    // your tests cases here
-  }
-
-  for _, tt := range tests {
-    t.Run(tt.name, func(t *testing.T) {
-      // actual testing logic. probably set the env var, set the global flag based on the cliFlag, then
-      // call getCacheDir() and make sure the return value is equal to the expectedDir
-    }
-  }
-}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -33,9 +33,8 @@ type testpair struct {
 func TestCacheDir(t *testing.T) {
 	homeDir, err := homedir.Dir()
 	if err != nil {
-		t.Errorf("\nError getting home dir")
+		t.Errorf("error getting home dir: %s", err.Error())
 	}
-
 	tests := []struct {
 		name        string
 		cliFlag     string

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,7 +31,11 @@ type testpair struct {
 }
 
 func TestCacheDir(t *testing.T) {
-	homeDir, _ := homedir.Dir()
+	homeDir, err := homedir.Dir()
+	if err != nil {
+		t.Errorf("\nError getting home dir")
+	}
+
 	tests := []struct {
 		name        string
 		cliFlag     string
@@ -39,7 +43,6 @@ func TestCacheDir(t *testing.T) {
 		expectedDir string
 		imageName   string
 	}{
-		// name, cliFlag, envVar, expectedDir
 		{
 			name:        "default cache is at $HOME",
 			cliFlag:     "",
@@ -80,7 +83,10 @@ func TestCacheDir(t *testing.T) {
 			cacheDir = tt.cliFlag
 
 			// call getCacheDir and make sure return is equal to expected
-			actualDir, _ := getCacheDir(tt.imageName)
+			actualDir, err := getCacheDir(tt.imageName)
+			if err != nil {
+				t.Errorf("%s\nError getting cache dir", tt.name)
+			}
 
 			if path.Dir(actualDir) != tt.expectedDir {
 				t.Errorf("%s\nExpected: %v\nGot: %v", tt.name, tt.expectedDir, actualDir)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,7 +16,76 @@ limitations under the License.
 
 package cmd
 
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
 type testpair struct {
 	input       []string
 	shouldError bool
+}
+
+func TestCacheDir(t *testing.T) {
+	homeDir, _ := homedir.Dir()
+	tests := []struct {
+		name        string
+		cliFlag     string
+		envVar      string
+		expectedDir string
+		imageName   string
+	}{
+		// name, cliFlag, envVar, expectedDir
+		{
+			name:        "default cache is at $HOME",
+			cliFlag:     "",
+			envVar:      "",
+			expectedDir: filepath.Join(homeDir, ".container-diff", "cache"),
+			imageName:   "pancakes",
+		},
+		{
+			name:        "setting cache via --cache-dir",
+			cliFlag:     "/tmp",
+			envVar:      "",
+			expectedDir: "/tmp/.container-diff/cache",
+			imageName:   "pancakes",
+		},
+		{
+			name:        "setting cache via CONTAINER_DIFF_CACHEDIR",
+			cliFlag:     "",
+			envVar:      "/tmp",
+			expectedDir: "/tmp/.container-diff/cache",
+			imageName:   "pancakes",
+		},
+		{
+			name:        "command line --cache-dir takes preference to CONTAINER_DIFF_CACHEDIR",
+			cliFlag:     "/tmp",
+			envVar:      "/opt",
+			expectedDir: "/tmp/.container-diff/cache",
+			imageName:   "pancakes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// set any environment variables
+			if tt.envVar != "" {
+				os.Setenv("CONTAINER_DIFF_CACHEDIR", tt.envVar)
+			}
+			// Set global flag for cache based on --cache-dir
+			cacheDir = tt.cliFlag
+
+			// call getCacheDir and make sure return is equal to expected
+			actualDir, _ := getCacheDir(tt.imageName)
+
+			if path.Dir(actualDir) != tt.expectedDir {
+				t.Errorf("%s\nExpected: %v\nGot: %v", tt.name, tt.expectedDir, actualDir)
+			}
+		},
+		)
+	}
 }


### PR DESCRIPTION
This PR will close #273, allowing the user to specify a custom cache directory base (different from $HOME) to allow for better use in cluster environments (where the $HOME is very tiny!) Specifically, the order of operations is the following:

 1. First preference goes to command line setting
 2. Second preference goes to environment variable set as `CONTAINER_DIFF_CACHEDIR`
 3. Third preference goes to default ($HOME) as is now.

Additional notes are included below. 

## Variable Type
I added the variable as a string variable, with option for a single character (c)
to mirror the same ability for "no-cache"

```golang
cmd.Flags().StringVarP(&cacheDir, "cache", "c", "", "cache directory base to create .container-diff (default is $HOME).")
```
Since all commands can use the cache, I added it to `addSharedFlags`.

With the above, the variable goes into "cacheDir" to be consistent with the use
of cacheDir in pkg/util/image_utils.g. The previous function was also called "cacheDir", but
I renamed to be "getCacheDir" so it more accurately reflects its purpose. The command
line call (for analyze) now looks like this:

```bash
$ ./out/container-diff analyze
Error: 'analyze' requires one image as an argument: container-diff analyze [image]
Usage:
  container-diff analyze [flags]

Flags:
  -c, --cache string      cache directory base to create .container-diff (default is $HOME).
  -h, --help              help for analyze
  -j, --json              JSON Output defines if the diff should be returned in a human readable format (false) or a JSON (true).
  -n, --no-cache          Set this to force retrieval of image filesystem on each run.
  -o, --order             Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.
  -q, --quiet             Suppress output to stderr.
  -s, --save              Set this flag to save rather than remove the final image filesystems on exit.
  -t, --type Diff Types   This flag sets the list of analyzer types to use. Set it repeatedly to use multiple analyzers.

Global Flags:
      --format string      Format to output diff in.
  -v, --verbosity string   This flag controls the verbosity of container-diff. (default "warning")

'analyze' requires one image as an argument: container-diff analyze [image]
```
Notice that I tell the user that it's a base where we create `.container-diff`.

## Examples
We can test that the default cache stiill goes to $HOME. Here I am not specifying anything in the environment or command line (and clearing any old cache that might have been there).

```bash
rm -rf $HOME/.container-diff/cache
$ ./out/container-diff analyze ubuntu
...
```
He's back!
```
$ ls /home/vanessa/.container-diff/cache/
ubuntu
```
And then we can test setting something else via command line:

```bash
$ ./out/container-diff analyze ubuntu --cache /tmp
```
And we see the cache with root as /tmp as we would want.

```$ ls /tmp/.container-diff/
cache
```

And then via an environment variable, removing the previous first.

```bash
rm -rf /tmp/.container-diff
$ CONTAINER_DIFF_CACHEDIR=/tmp ./out/container-diff analyze ubuntu
$ ls /tmp/.container-diff/cache/
ubuntu
```

Finally, command line takes preference over environment.

```bash
rm -rf /tmp/.container-diff

# This export should be ignored
export CONTAINER_DIFF_CACHEDIR=/tmp

# We will use this one on the command line (preference)
mkdir -p $CONTAINER_DIFF_CACHEDIR/pancakes

# pancakes is set in on command line, should take preference

$ ./out/container-diff analyze ubuntu --cache $CONTAINER_DIFF_CACHEDIR/pancakes
$ ls /tmp/pancakes/.container-diff/
cache
```

This is my first goLang PR so I'd love some guidance on how to write tests. I should have some time later today. Thanks for your help!