### PR TITLE
Fixed concurrent map write in image diffing

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -71,13 +71,12 @@ func checkFilenameFlag(_ []string) error {
 }
 
 // processImage is a concurrency-friendly wrapper around getImageForName
-func processImage(imageName string, imageMap map[string]*pkgutil.Image, wg *sync.WaitGroup, errChan chan<- error) {
-	defer wg.Done()
+func processImage(imageName string, errChan chan<- error) *pkgutil.Image {
 	image, err := getImage(imageName)
 	if err != nil {
 		errChan <- fmt.Errorf("error retrieving image %s: %s", imageName, err)
 	}
-	imageMap[imageName] = &image
+	return &image
 }
 
 // collects errors from a channel and combines them
@@ -109,18 +108,24 @@ func diffImages(image1Arg, image2Arg string, diffArgs []string) error {
 
 	logrus.Infof("starting diff on images %s and %s, using differs: %s\n", image1Arg, image2Arg, diffArgs)
 
-	imageMap := map[string]*pkgutil.Image{}
+	var image1, image2 *pkgutil.Image
 	errChan := make(chan error, 2)
 
-	go processImage(image1Arg, imageMap, &wg, errChan)
-	go processImage(image2Arg, imageMap, &wg, errChan)
+	go func() {
+		defer wg.Done()
+		image1 = processImage(image1Arg, errChan)
+	}()
+	go func() {
+		defer wg.Done()
+		image2 = processImage(image2Arg, errChan)
+	}()
 
 	wg.Wait()
 	close(errChan)
 
 	if noCache && !save {
-		defer pkgutil.CleanupImage(*imageMap[image1Arg])
-		defer pkgutil.CleanupImage(*imageMap[image2Arg])
+		defer pkgutil.CleanupImage(*image1)
+		defer pkgutil.CleanupImage(*image2)
 	}
 
 	if err := readErrorsFromChannel(errChan); err != nil {
@@ -129,8 +134,8 @@ func diffImages(image1Arg, image2Arg string, diffArgs []string) error {
 
 	logrus.Info("computing diffs")
 	req := differs.DiffRequest{
-		Image1:    *imageMap[image1Arg],
-		Image2:    *imageMap[image2Arg],
+		Image1:    *image1,
+		Image2:    *image2,
 		DiffTypes: diffTypes}
 	diffs, err := req.GetDiff()
 	if err != nil {
@@ -140,15 +145,15 @@ func diffImages(image1Arg, image2Arg string, diffArgs []string) error {
 
 	if filename != "" {
 		logrus.Info("computing filename diffs")
-		err := diffFile(imageMap[image1Arg], imageMap[image2Arg])
+		err := diffFile(image1, image2)
 		if err != nil {
 			return err
 		}
 	}
 
 	if noCache && save {
-		logrus.Infof("images were saved at %s and %s", imageMap[image1Arg].FSPath,
-			imageMap[image2Arg].FSPath)
+		logrus.Infof("images were saved at %s and %s", image1.FSPath,
+			image2.FSPath)
 	}
 	return nil
 }


### PR DESCRIPTION
When running container-diff, I got the following panic due to a race condition:
```
fatal error: concurrent map writes

goroutine 19 [running]:
runtime.throw(0x15bd053, 0x15)
	/usr/local/go/src/runtime/panic.go:605 +0x95 fp=0xc42006bdd8 sp=0xc42006bdb8 pc=0x102b6f5
runtime.mapassign_faststr(0x15065a0, 0xc42030c090, 0x7ffeefbff90c, 0x11, 0x2)
	/usr/local/go/src/runtime/hashmap_fast.go:783 +0x4f5 fp=0xc42006be58 sp=0xc42006bdd8 pc=0x100d0c5
github.com/GoogleContainerTools/container-diff/cmd.processImage(0x7ffeefbff90c, 0x11, 0xc42030c090, 0xc4202fb5b0, 0xc420262ae0)
	/go/src/github.com/GoogleContainerTools/container-diff/cmd/diff.go:80 +0x2af fp=0xc42006bfb8 sp=0xc42006be58 pc=0x146239f
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc42006bfc0 sp=0xc42006bfb8 pc=0x105bc11
created by github.com/GoogleContainerTools/container-diff/cmd.diffImages
	/go/src/github.com/GoogleContainerTools/container-diff/cmd/diff.go:115 +0x2fc
```
The variable `imageMap` was being written to by two different goroutines (processImage) at the same time. This patch fixes that race condition by getting rid of the map altogether and keeping each variable separate.