### PR TITLE
Enhancement - save to file

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -158,7 +158,11 @@ func diffFile(image1, image2 *pkgutil.Image) error {
 	if err != nil {
 		return err
 	}
-	util.TemplateOutput(diff, "FilenameDiff")
+	writer, err := getWriter(outputFile)
+	if err != nil {
+		return err
+	}
+	util.TemplateOutput(writer, diff, "FilenameDiff")
 	return nil
 }
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -163,6 +163,10 @@ func diffFile(image1, image2 *pkgutil.Image) error {
 		return err
 	}
 	util.TemplateOutput(writer, diff, "FilenameDiff")
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,6 +41,7 @@ var save bool
 var types diffTypes
 var noCache bool
 
+var outputFile string
 var cacheDir string
 var LogLevel string
 var format string
@@ -70,6 +72,7 @@ Tarballs can also be specified by simply providing the path to the .tar, .tar.gz
 }
 
 func outputResults(resultMap map[string]util.Result) {
+
 	// Outputs diff/analysis results in alphabetical order by analyzer name
 	sortedTypes := []string{}
 	for analyzerType := range resultMap {
@@ -77,20 +80,27 @@ func outputResults(resultMap map[string]util.Result) {
 	}
 	sort.Strings(sortedTypes)
 
+	// Get the writer
+	writer, err := getWriter(outputFile)
+	if err != nil {
+		logrus.Error(err)
+	}
+
 	results := make([]interface{}, len(resultMap))
 	for i, analyzerType := range sortedTypes {
 		result := resultMap[analyzerType]
 		if json {
 			results[i] = result.OutputStruct()
 		} else {
-			err := result.OutputText(analyzerType, format)
+			err := result.OutputText(writer, analyzerType, format)
 			if err != nil {
 				logrus.Error(err)
 			}
 		}
 	}
 	if json {
-		err := util.JSONify(results)
+
+		err := util.JSONify(writer, results)
 		if err != nil {
 			logrus.Error(err)
 		}
@@ -162,6 +172,29 @@ func getCacheDir(imageName string) (string, error) {
 	return filepath.Join(rootDir, filepath.Clean(imageName)), nil
 }
 
+func getWriter(outputFile string) (io.Writer, error) {
+	var err error
+	var outWriter io.Writer
+
+	// If the user specifies an output file, ensure exists
+	if outputFile != "" {
+
+		// The file can't exist, we would overwrite it
+		if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
+			return os.Stdout, errors.Wrap(err, "file exists, will not overwrite")
+		}
+
+		// Otherwise, output file is an io.writer
+		outWriter, err = os.Create(outputFile)
+
+	}
+	// If still doesn't exist, return stdout as the io.Writer
+	if outputFile == "" {
+		outWriter = os.Stdout
+	}
+	return outWriter, err
+}
+
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&LogLevel, "verbosity", "v", "warning", "This flag controls the verbosity of container-diff.")
 	RootCmd.PersistentFlags().StringVarP(&format, "format", "", "", "Format to output diff in.")
@@ -201,5 +234,5 @@ func addSharedFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&util.SortSize, "order", "o", false, "Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "n", false, "Set this to force retrieval of image filesystem on each run.")
 	cmd.Flags().StringVarP(&cacheDir, "cache-dir", "c", "", "cache directory base to create .container-diff (default is $HOME).")
-
+	cmd.Flags().StringVarP(&outputFile, "output", "w", "", "output file to write to (default writes to STDOUT).")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ var types diffTypes
 var noCache bool
 
 var outputFile string
+var forceWrite bool
 var cacheDir string
 var LogLevel string
 var format string
@@ -179,9 +180,11 @@ func getWriter(outputFile string) (io.Writer, error) {
 	// If the user specifies an output file, ensure exists
 	if outputFile != "" {
 
-		// The file can't exist, we would overwrite it
+		// Don't overwrite a file that exists, unless given --force
 		if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
-			return os.Stdout, errors.Wrap(err, "file exists, will not overwrite")
+			if !forceWrite {
+				logrus.Error("file exist, will not overwrite.")
+			}
 		}
 
 		// Otherwise, output file is an io.writer
@@ -234,5 +237,6 @@ func addSharedFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&util.SortSize, "order", "o", false, "Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "n", false, "Set this to force retrieval of image filesystem on each run.")
 	cmd.Flags().StringVarP(&cacheDir, "cache-dir", "c", "", "cache directory base to create .container-diff (default is $HOME).")
-	cmd.Flags().StringVarP(&outputFile, "output", "w", "", "output file to write to (default writes to STDOUT).")
+	cmd.Flags().StringVarP(&outputFile, "output", "w", "", "output file to write to (default writes to the screen).")
+	cmd.Flags().BoolVar(&forceWrite, "force", false, "force overwrite output file, if exists already.")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,6 @@ Tarballs can also be specified by simply providing the path to the .tar, .tar.gz
 }
 
 func outputResults(resultMap map[string]util.Result) {
-
 	// Outputs diff/analysis results in alphabetical order by analyzer name
 	sortedTypes := []string{}
 	for analyzerType := range resultMap {
@@ -84,7 +83,7 @@ func outputResults(resultMap map[string]util.Result) {
 	// Get the writer
 	writer, err := getWriter(outputFile)
 	if err != nil {
-		logrus.Error(err)
+		errors.Wrap(err, "getting writer for output file")
 	}
 
 	results := make([]interface{}, len(resultMap))
@@ -100,7 +99,6 @@ func outputResults(resultMap map[string]util.Result) {
 		}
 	}
 	if json {
-
 		err := util.JSONify(writer, results)
 		if err != nil {
 			logrus.Error(err)
@@ -176,20 +174,14 @@ func getCacheDir(imageName string) (string, error) {
 func getWriter(outputFile string) (io.Writer, error) {
 	var err error
 	var outWriter io.Writer
-
 	// If the user specifies an output file, ensure exists
 	if outputFile != "" {
-
 		// Don't overwrite a file that exists, unless given --force
-		if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
-			if !forceWrite {
-				logrus.Error("file exist, will not overwrite.")
-			}
+		if _, err := os.Stat(outputFile); !os.IsNotExist(err) && !forceWrite {
+			errors.Wrap(err, "file exist, will not overwrite.")
 		}
-
 		// Otherwise, output file is an io.writer
 		outWriter, err = os.Create(outputFile)
-
 	}
 	// If still doesn't exist, return stdout as the io.Writer
 	if outputFile == "" {

--- a/util/analyze_output_utils.go
+++ b/util/analyze_output_utils.go
@@ -19,6 +19,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/GoogleContainerTools/container-diff/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -26,7 +27,7 @@ import (
 
 type Result interface {
 	OutputStruct() interface{}
-	OutputText(resultType string, format string) error
+	OutputText(writer io.Writer, resultType string, format string) error
 }
 
 type AnalyzeResult struct {
@@ -41,14 +42,14 @@ func (r ListAnalyzeResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r ListAnalyzeResult) OutputText(resultType string, format string) error {
+func (r ListAnalyzeResult) OutputText(writer io.Writer, resultType string, format string) error {
 	analysis, valid := r.Analysis.([]string)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type []string")
 		return fmt.Errorf("Could not output %s analysis result", r.AnalyzeType)
 	}
 	r.Analysis = analysis
-	return TemplateOutputFromFormat(r, "ListAnalyze", format)
+	return TemplateOutputFromFormat(writer, r, "ListAnalyze", format)
 
 }
 
@@ -73,7 +74,7 @@ func (r MultiVersionPackageAnalyzeResult) OutputStruct() interface{} {
 	return output
 }
 
-func (r MultiVersionPackageAnalyzeResult) OutputText(resultType string, format string) error {
+func (r MultiVersionPackageAnalyzeResult) OutputText(writer io.Writer, resultType string, format string) error {
 	analysis, valid := r.Analysis.(map[string]map[string]PackageInfo)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type map[string]map[string]PackageInfo")
@@ -91,7 +92,7 @@ func (r MultiVersionPackageAnalyzeResult) OutputText(resultType string, format s
 		AnalyzeType: r.AnalyzeType,
 		Analysis:    strAnalysis,
 	}
-	return TemplateOutputFromFormat(strResult, "MultiVersionPackageAnalyze", format)
+	return TemplateOutputFromFormat(writer, strResult, "MultiVersionPackageAnalyze", format)
 }
 
 type SingleVersionPackageAnalyzeResult AnalyzeResult
@@ -115,7 +116,7 @@ func (r SingleVersionPackageAnalyzeResult) OutputStruct() interface{} {
 	return output
 }
 
-func (r SingleVersionPackageAnalyzeResult) OutputText(diffType string, format string) error {
+func (r SingleVersionPackageAnalyzeResult) OutputText(writer io.Writer, diffType string, format string) error {
 	analysis, valid := r.Analysis.(map[string]PackageInfo)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type map[string]PackageInfo")
@@ -133,7 +134,7 @@ func (r SingleVersionPackageAnalyzeResult) OutputText(diffType string, format st
 		AnalyzeType: r.AnalyzeType,
 		Analysis:    strAnalysis,
 	}
-	return TemplateOutputFromFormat(strResult, "SingleVersionPackageAnalyze", format)
+	return TemplateOutputFromFormat(writer, strResult, "SingleVersionPackageAnalyze", format)
 }
 
 type SingleVersionPackageLayerAnalyzeResult AnalyzeResult
@@ -173,7 +174,7 @@ func (r SingleVersionPackageLayerAnalyzeResult) OutputStruct() interface{} {
 	return output
 }
 
-func (r SingleVersionPackageLayerAnalyzeResult) OutputText(diffType string, format string) error {
+func (r SingleVersionPackageLayerAnalyzeResult) OutputText(writer io.Writer, diffType string, format string) error {
 	analysis, valid := r.Analysis.(PackageLayerDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type PackageLayerDiff")
@@ -205,7 +206,7 @@ func (r SingleVersionPackageLayerAnalyzeResult) OutputText(diffType string, form
 		AnalyzeType: r.AnalyzeType,
 		Analysis:    analysisOutput,
 	}
-	return TemplateOutputFromFormat(strResult, "SingleVersionPackageLayerAnalyze", format)
+	return TemplateOutputFromFormat(writer, strResult, "SingleVersionPackageLayerAnalyze", format)
 }
 
 type PackageOutput struct {
@@ -263,7 +264,7 @@ func (r FileAnalyzeResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r FileAnalyzeResult) OutputText(analyzeType string, format string) error {
+func (r FileAnalyzeResult) OutputText(writer io.Writer, analyzeType string, format string) error {
 	analysis, valid := r.Analysis.([]util.DirectoryEntry)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type []DirectoryEntry")
@@ -286,7 +287,7 @@ func (r FileAnalyzeResult) OutputText(analyzeType string, format string) error {
 		AnalyzeType: r.AnalyzeType,
 		Analysis:    strAnalysis,
 	}
-	return TemplateOutputFromFormat(strResult, "FileAnalyze", format)
+	return TemplateOutputFromFormat(writer, strResult, "FileAnalyze", format)
 }
 
 type FileLayerAnalyzeResult AnalyzeResult
@@ -310,7 +311,7 @@ func (r FileLayerAnalyzeResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r FileLayerAnalyzeResult) OutputText(analyzeType string, format string) error {
+func (r FileLayerAnalyzeResult) OutputText(writer io.Writer, analyzeType string, format string) error {
 	analysis, valid := r.Analysis.([][]util.DirectoryEntry)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type []DirectoryEntry")
@@ -338,7 +339,7 @@ func (r FileLayerAnalyzeResult) OutputText(analyzeType string, format string) er
 		AnalyzeType: r.AnalyzeType,
 		Analysis:    strDirectoryEntries,
 	}
-	return TemplateOutputFromFormat(strResult, "FileLayerAnalyze", format)
+	return TemplateOutputFromFormat(writer, strResult, "FileLayerAnalyze", format)
 }
 
 type SizeAnalyzeResult AnalyzeResult
@@ -353,7 +354,7 @@ func (r SizeAnalyzeResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r SizeAnalyzeResult) OutputText(analyzeType string, format string) error {
+func (r SizeAnalyzeResult) OutputText(writer io.Writer, analyzeType string, format string) error {
 	analysis, valid := r.Analysis.([]SizeEntry)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type []SizeEntry")
@@ -371,7 +372,7 @@ func (r SizeAnalyzeResult) OutputText(analyzeType string, format string) error {
 		AnalyzeType: r.AnalyzeType,
 		Analysis:    strAnalysis,
 	}
-	return TemplateOutputFromFormat(strResult, "SizeAnalyze", format)
+	return TemplateOutputFromFormat(writer, strResult, "SizeAnalyze", format)
 }
 
 type SizeLayerAnalyzeResult AnalyzeResult
@@ -386,7 +387,7 @@ func (r SizeLayerAnalyzeResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r SizeLayerAnalyzeResult) OutputText(analyzeType string, format string) error {
+func (r SizeLayerAnalyzeResult) OutputText(writer io.Writer, analyzeType string, format string) error {
 	analysis, valid := r.Analysis.([]SizeEntry)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type []SizeEntry")
@@ -404,5 +405,5 @@ func (r SizeLayerAnalyzeResult) OutputText(analyzeType string, format string) er
 		AnalyzeType: r.AnalyzeType,
 		Analysis:    strAnalysis,
 	}
-	return TemplateOutputFromFormat(strResult, "SizeLayerAnalyze", format)
+	return TemplateOutputFromFormat(writer, strResult, "SizeLayerAnalyze", format)
 }

--- a/util/diff_output_utils.go
+++ b/util/diff_output_utils.go
@@ -19,6 +19,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -52,7 +53,7 @@ func (r MultiVersionPackageDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r MultiVersionPackageDiffResult) OutputText(diffType string, format string) error {
+func (r MultiVersionPackageDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
 	diff, valid := r.Diff.(MultiVersionPackageDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the MultiVersionPackageDiff struct")
@@ -84,7 +85,7 @@ func (r MultiVersionPackageDiffResult) OutputText(diffType string, format string
 			InfoDiff:  strInfoDiff,
 		},
 	}
-	return TemplateOutputFromFormat(strResult, "MultiVersionPackageDiff", format)
+	return TemplateOutputFromFormat(writer, strResult, "MultiVersionPackageDiff", format)
 }
 
 func getMultiVersionInfoDiffOutput(infoDiff []MultiVersionInfo) []MultiVersionInfo {
@@ -118,7 +119,7 @@ func (r SingleVersionPackageDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r SingleVersionPackageDiffResult) OutputText(diffType string, format string) error {
+func (r SingleVersionPackageDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
 	diff, valid := r.Diff.(PackageDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the PackageDiff struct")
@@ -150,7 +151,7 @@ func (r SingleVersionPackageDiffResult) OutputText(diffType string, format strin
 			InfoDiff:  strInfoDiff,
 		},
 	}
-	return TemplateOutputFromFormat(strResult, "SingleVersionPackageDiff", format)
+	return TemplateOutputFromFormat(writer, strResult, "SingleVersionPackageDiff", format)
 }
 
 func getSingleVersionInfoDiffOutput(infoDiff []Info) []Info {
@@ -191,7 +192,7 @@ func (r SingleVersionPackageLayerDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r SingleVersionPackageLayerDiffResult) OutputText(diffType string, format string) error {
+func (r SingleVersionPackageLayerDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
 	diff, valid := r.Diff.(PackageLayerDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the PackageLayerDiff struct")
@@ -225,7 +226,7 @@ func (r SingleVersionPackageLayerDiffResult) OutputText(diffType string, format 
 		DiffType: r.DiffType,
 		Diff:     diffOutputs,
 	}
-	return TemplateOutputFromFormat(strResult, "SingleVersionPackageLayerDiff", format)
+	return TemplateOutputFromFormat(writer, strResult, "SingleVersionPackageLayerDiff", format)
 }
 
 type HistDiffResult DiffResult
@@ -234,8 +235,8 @@ func (r HistDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r HistDiffResult) OutputText(diffType string, format string) error {
-	return TemplateOutputFromFormat(r, "HistDiff", format)
+func (r HistDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
+	return TemplateOutputFromFormat(writer, r, "HistDiff", format)
 }
 
 type MetadataDiffResult DiffResult
@@ -244,8 +245,8 @@ func (r MetadataDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r MetadataDiffResult) OutputText(diffType string, format string) error {
-	return TemplateOutputFromFormat(r, "MetadataDiff", format)
+func (r MetadataDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
+	return TemplateOutputFromFormat(writer, r, "MetadataDiff", format)
 }
 
 type DirDiffResult DiffResult
@@ -261,7 +262,7 @@ func (r DirDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r DirDiffResult) OutputText(diffType string, format string) error {
+func (r DirDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
 	diff, valid := r.Diff.(DirDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the DirDiff struct")
@@ -294,7 +295,7 @@ func (r DirDiffResult) OutputText(diffType string, format string) error {
 			Mods: strMods,
 		},
 	}
-	return TemplateOutputFromFormat(strResult, "DirDiff", format)
+	return TemplateOutputFromFormat(writer, strResult, "DirDiff", format)
 }
 
 type SizeDiffResult DiffResult
@@ -310,7 +311,7 @@ func (r SizeDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r SizeDiffResult) OutputText(diffType string, format string) error {
+func (r SizeDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
 	diff, valid := r.Diff.([]SizeDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should be of type []SizeDiff")
@@ -330,7 +331,7 @@ func (r SizeDiffResult) OutputText(diffType string, format string) error {
 		DiffType: r.DiffType,
 		Diff:     strDiff,
 	}
-	return TemplateOutputFromFormat(strResult, "SizeDiff", format)
+	return TemplateOutputFromFormat(writer, strResult, "SizeDiff", format)
 }
 
 type SizeLayerDiffResult DiffResult
@@ -346,7 +347,7 @@ func (r SizeLayerDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r SizeLayerDiffResult) OutputText(diffType string, format string) error {
+func (r SizeLayerDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
 	diff, valid := r.Diff.([]SizeDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should be of type []SizeDiff")
@@ -366,7 +367,7 @@ func (r SizeLayerDiffResult) OutputText(diffType string, format string) error {
 		DiffType: r.DiffType,
 		Diff:     strDiff,
 	}
-	return TemplateOutputFromFormat(strResult, "SizeLayerDiff", format)
+	return TemplateOutputFromFormat(writer, strResult, "SizeLayerDiff", format)
 }
 
 type MultipleDirDiffResult DiffResult
@@ -384,7 +385,7 @@ func (r MultipleDirDiffResult) OutputStruct() interface{} {
 	return r
 }
 
-func (r MultipleDirDiffResult) OutputText(diffType string, format string) error {
+func (r MultipleDirDiffResult) OutputText(writer io.Writer, diffType string, format string) error {
 	diff, valid := r.Diff.(MultipleDirDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the MultipleDirDiff struct")
@@ -428,5 +429,5 @@ func (r MultipleDirDiffResult) OutputText(diffType string, format string) error 
 		DiffType: r.DiffType,
 		Diff:     strDiffs,
 	}
-	return TemplateOutputFromFormat(strResult, "MultipleDirDiff", format)
+	return TemplateOutputFromFormat(writer, strResult, "MultipleDirDiff", format)
 }


### PR DESCRIPTION
This pull request will close #275, specifically allowing the user to specify a file to write to. Notes are included below. 

### What is the entrypoint for the user?

The application flow beings with the addition of a new variable, `outputFile`

```golang
cmd.Flags().StringVarP(&outputFile, "output", "w", "", "output file to write to (default writes to STDOUT).")
```
It's a string, the default being empty, that if not empty, will serve two purposes:

  - serve as a boolean to indicate we want to write to file
  - the string variable itself provides the path to the file.

With any write to file it goes without saying we don't want to overwrite by default, but we can give the user a `--force` variable to push it.

```golang
cmd.Flags().BoolVar(&forceWrite, "force", false, "force overwrite output file, if exists already.")
```

### Variable Choices

I chose `output` for the command line flag (`--output`) because it reads nicely into a sentence, e.g., "--output=/path/to/file.json" reads to output goes to this file path. I also chose `w` for the single character (well, o was taken) but also because `w`  can also stand for "write," sort of like the `gofmt -w <file>` command.  So "-w /path/to/file.json" reads to "write to this file path).

### What is the Client Flow?

The flag is revealed as an option `--output` if we do `analyze` or `diff`. Note that I also added a `force` option in the case that the file exists. The user can choose to overwrite it with `--force`.

```bash
$ ./out/container-diff analyze --help
Analyzes an image using the specifed analyzers as indicated via flags (see documentation for available ones).

Usage:
  container-diff analyze [flags]

Flags:
  -c, --cache-dir string   cache directory base to create .container-diff (default is $HOME).
      --force              force overwrite output file, if exists already.
  -h, --help               help for analyze
  -j, --json               JSON Output defines if the diff should be returned in a human readable format (false) or a JSON (true).
  -n, --no-cache           Set this to force retrieval of image filesystem on each run.
  -o, --order              Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.
  -w, --output string      output file to write to (default writes to the screen).
  -q, --quiet              Suppress output to stderr.
  -s, --save               Set this flag to save rather than remove the final image filesystems on exit.
  -t, --type Diff Types    This flag sets the list of analyzer types to use. Set it repeatedly to use multiple analyzers.

Global Flags:
      --format string      Format to output diff in.
  -v, --verbosity string   This flag controls the verbosity of container-diff. (default "warning")
```

And here is for diff, it's mostly the same.

```bash
$ ./out/container-diff diff --help
Usage:
  container-diff diff [flags]

Flags:
  -c, --cache-dir string   cache directory base to create .container-diff (default is $HOME).
  -f, --filename string    Set this flag to the path of a file in both containers to view the diff of the file. Must be used with --types=file flag.
      --force              force overwrite output file, if exists already.
  -h, --help               help for diff
  -j, --json               JSON Output defines if the diff should be returned in a human readable format (false) or a JSON (true).
  -n, --no-cache           Set this to force retrieval of image filesystem on each run.
  -o, --order              Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.
  -w, --output string      output file to write to (default writes to the screen).
  -q, --quiet              Suppress output to stderr.
  -s, --save               Set this flag to save rather than remove the final image filesystems on exit.
  -t, --type Diff Types    This flag sets the list of analyzer types to use. Set it repeatedly to use multiple analyzers.

Global Flags:
      --format string      Format to output diff in.
  -v, --verbosity string   This flag controls the verbosity of container-diff. (default "warning")
```

I specifically didn't add a short hand for "force." If a user wants to overwrite a file, it's a pretty big deal, and if they might mess up the specification of one letter (and accidentally overwrite) I don't want to risk this.

### Manual Testing

We can first test that, without any specification of `--output`, it still works (and prints to stdout).

```bash
$ ./out/container-diff analyze ubuntu

-----Size-----

Analysis for ubuntu:
IMAGE         DIGEST                                                                         SIZE
ubuntu        sha256:acd85db6e4b18aafa7fcde5480872909bd8e6d5fbd4e5e790ecc09acc06a8b78        68.6M
```

Now let's write to a text file.

```bash
$ ./out/container-diff analyze --output /tmp/file.txt ubuntu
```
```bash
$ cat /tmp/file.txt

-----Size-----

Analysis for ubuntu:
IMAGE         DIGEST                                                                         SIZE
ubuntu        sha256:acd85db6e4b18aafa7fcde5480872909bd8e6d5fbd4e5e790ecc09acc06a8b78        68.6M
```

We can then try to write to the same file, it shouldn't allow us!

```bash
./out/container-diff analyze --output /tmp/file.txt ubuntu
ERRO[0001] file exist, will not overwrite.
```

...unless we tell it to force! (Use the force, logrus)

```bash
$ ./out/container-diff analyze --output /tmp/file.txt --force ubuntu
```
(Note no error messages).

We can do all of the above but specify json output.

```bash
$ ./out/container-diff analyze --output /tmp/file.json --json ubuntu
$ cat /tmp/file.json 
[
  {
    "Image": "ubuntu",
    "AnalyzeType": "Size",
    "Analysis": [
      {
        "Name": "ubuntu",
        "Digest": "sha256:acd85db6e4b18aafa7fcde5480872909bd8e6d5fbd4e5e790ecc09acc06a8b78",
        "Size": 71945016
      }
    ]
  }
]
```
```bash
$ ./out/container-diff analyze --output/tmp/file.json --json ubuntu
ERRO[0001] file exist, will not overwrite.              
```
```bash
$ ./out/container-diff analyze --output /tmp/file.json --force --json ubuntu
```

I think that's about it! I'm guessing you will want some tests? Let's have (high level discussion) on what we want to test (and recommendations for doing things like writing temporary files, organization and naming, etc.) and then I can give a GO at that too (pun, harhar).