### PR TITLE
Adding Github Action to run Container Diff

### DIFF
--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -1,0 +1,44 @@
+FROM golang:1.11.3-stretch
+
+# docker build -f actions/Dockerfile -t googlecontainertools/container-diff .
+
+RUN apt-get update && \
+    apt-get install -y automake \
+                       libffi-dev \ 
+                       libxml2 \
+                       libxml2-dev \
+                       libxslt-dev \
+                       libxslt1-dev \
+                       git \
+                       gcc g++ \
+                       wget \
+                       locales
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
+
+LABEL "com.github.actions.name"="container-diff GitHub Action"
+LABEL "com.github.actions.description"="use Container-Diff in Github Actions Workflows"
+LABEL "com.github.actions.icon"="cloud"
+LABEL "com.github.actions.color"="blue"
+
+LABEL "repository"="https://www.github.com/GoogleContainerTools/container-diff"
+LABEL "homepage"="https://www.github.com/GoogleContainerTools/container-diff"
+LABEL "maintainer"="Google Inc."
+
+# Install container-diff from master
+RUN go get github.com/GoogleContainerTools/container-diff && \
+    cd ${GOPATH}/src/github.com/GoogleContainerTools/container-diff && \
+    go get && \
+    make && \
+    go install && \
+    mkdir -p /code && \
+    apt-get autoremove
+
+RUN mkdir -p /root/.docker && \
+    echo {} > /root/.docker/config.json
+
+ENTRYPOINT ["container-diff"]

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -44,4 +44,4 @@ RUN mkdir -p /root/.docker && \
     echo {} > /root/.docker/config.json && \
     chmod u+x /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -43,5 +43,3 @@ ADD entrypoint.sh /entrypoint.sh
 RUN mkdir -p /root/.docker && \
     echo {} > /root/.docker/config.json && \
     chmod u+x /entrypoint.sh
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -43,3 +43,5 @@ ADD entrypoint.sh /entrypoint.sh
 RUN mkdir -p /root/.docker && \
     echo {} > /root/.docker/config.json && \
     chmod u+x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -38,7 +38,10 @@ RUN go get github.com/GoogleContainerTools/container-diff && \
     mkdir -p /code && \
     apt-get autoremove
 
-RUN mkdir -p /root/.docker && \
-    echo {} > /root/.docker/config.json
+ADD entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["container-diff"]
+RUN mkdir -p /root/.docker && \
+    echo {} > /root/.docker/config.json && \
+    chmod u+x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/README.md
+++ b/actions/README.md
@@ -64,8 +64,8 @@ action "push" {
 }
 
 action "Run container-diff" {
-  uses = "GoogleContainerTools/container-diff/actions@master"
   needs = ["build", "login", "push"]
+  uses = "GoogleContainerTools/container-diff/actions@master"
   args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", "--output", "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
 }
 

--- a/actions/README.md
+++ b/actions/README.md
@@ -21,7 +21,7 @@ workflow "Run container-diff isolated" {
 
 action "Run container-diff" {
   uses = "GoogleContainerTools/container-diff/actions@master"
-  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", "--output", "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
+  args = "analyze remote://vanessa/salad --type=pip type=apt --type=history --output /github/workspace/data.json --type=file --json --quiet --verbosity=panic"
 }
 
 action "list" {
@@ -66,7 +66,7 @@ action "push" {
 action "Run container-diff" {
   needs = ["build", "login", "push"]
   uses = "GoogleContainerTools/container-diff/actions@master"
-  args = ["analyze", "daemon://vanessa/salad", "--type=pip", "type=apt", "--type=history", "--output=/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
+  args = "analyze vanessa/salad --type=pip type=apt --type=history --output /github/workspace/data.json --type=file --json --quiet --verbosity=panic"
 }
 
 action "list" {

--- a/actions/README.md
+++ b/actions/README.md
@@ -14,14 +14,14 @@ Given an existing container on Docker Hub, we can run container diff
 without doing any kind of build.
 
 ```
-workflow "Run container-diff" {
+workflow "Run container-diff isolated" {
   on = "push"
   resolves = ["list"]
 }
 
 action "Run container-diff" {
   uses = "GoogleContainerTools/container-diff/actions@master"
-  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", --output "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
+  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", "--output", "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
 }
 
 action "list" {
@@ -66,7 +66,7 @@ action "push" {
 action "Run container-diff" {
   uses = "GoogleContainerTools/container-diff/actions@master"
   needs = ["build", "login", "push"]
-  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", --output "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
+  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", "--output", "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
 }
 
 action "list" {

--- a/actions/README.md
+++ b/actions/README.md
@@ -20,6 +20,7 @@ workflow "Run container-diff" {
 }
 
 action "Run container-diff" {
+  uses = "GoogleContainerTools/container-diff/actions@master"
   args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", --output "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
 }
 
@@ -63,6 +64,7 @@ action "push" {
 }
 
 action "Run container-diff" {
+  uses = "GoogleContainerTools/container-diff/actions@master"
   needs = ["build", "login", "push"]
   args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", --output "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
 }

--- a/actions/README.md
+++ b/actions/README.md
@@ -66,7 +66,7 @@ action "push" {
 action "Run container-diff" {
   needs = ["build", "login", "push"]
   uses = "GoogleContainerTools/container-diff/actions@master"
-  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", "--output", "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
+  args = ["analyze", "daemon://vanessa/salad", "--type=pip", "type=apt", "--type=history", "--output=/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
 }
 
 action "list" {

--- a/actions/README.md
+++ b/actions/README.md
@@ -1,0 +1,79 @@
+# Container Diff for Github Actions
+
+This is a Github Action to allow you to run Container Diff in a 
+[Github Actions](https://help.github.com/articles/about-github-actions/#about-github-actions)
+workflow. The intended use case is to build a Docker container from the repository,
+push it to Docker Hub, and then use container-diff to extract metadata for it that
+you can use in other workflows (such as deploying to Github pages). In
+the example below, we will show you how to build a container, push
+to Docker Hub, and then container diff.  Here is the entire workflow:
+
+## Example 1: Run Container Diff
+
+Given an existing container on Docker Hub, we can run container diff
+without doing any kind of build.
+
+```
+workflow "Run container-diff" {
+  on = "push"
+  resolves = ["list"]
+}
+
+action "Run container-diff" {
+  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", --output "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
+}
+
+action "list" {
+  needs = ["Run container-diff"]
+  uses = "actions/bin/sh@master"
+  runs = "ls"
+  args = ["/github/workspace"]
+}
+```
+
+In the above, we run container-diff to output apt and pip packages, history,
+and the filesystem for the container "vanessa/salad" that already exists on
+Docker Hub. We save the result to a data.json output file. The final step in 
+the workflow (list) is a courtesy to show that the data.json file is generated.
+
+## Example 2: Build, Deploy, Run Container Diff
+
+This next example is slightly more complicated in that it will run container-diff
+after a container is built and deployed from a Dockerfile present in the repository.
+
+```
+workflow "Run container-diff after deploy" {
+  on = "push"
+  resolves = ["Run container-diff"]
+}
+
+action "build" {
+  uses = "actions/docker/cli@master"
+  args = "build -t vanessa/salad ."
+}
+
+action "login" {
+  uses = "actions/docker/login@master"
+  secrets = ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
+}
+
+action "push" {
+  uses = "actions/docker/cli@master"
+  args = "push vanessa/salad"
+}
+
+action "Run container-diff" {
+  needs = ["build", "login", "push"]
+  args = ["analyze", "vanessa/salad", "--type=pip", "type=apt", "--type=history", --output "/github/workspace/data.json", "--type=file", "--json", "--quiet", "--verbosity=panic" ]
+}
+
+action "list" {
+  needs = ["Run container-diff"]
+  uses = "actions/bin/sh@master"
+  runs = "ls"
+  args = ["/github/workspace"]
+}
+```
+
+The intended use case of the above would be to, whenever you update your
+container, deploy its metadata to Github pages (or elsewhere).

--- a/actions/README.md
+++ b/actions/README.md
@@ -21,7 +21,7 @@ workflow "Run container-diff isolated" {
 
 action "Run container-diff" {
   uses = "GoogleContainerTools/container-diff/actions@master"
-  args = "analyze remote://vanessa/salad --type=pip type=apt --type=history --output /github/workspace/data.json --type=file --json --quiet --verbosity=panic"
+  args = ["analyze vanessa/salad --type=file --output=/github/workspace/data.json --json"]
 }
 
 action "list" {
@@ -66,7 +66,7 @@ action "push" {
 action "Run container-diff" {
   needs = ["build", "login", "push"]
   uses = "GoogleContainerTools/container-diff/actions@master"
-  args = "analyze vanessa/salad --type=pip type=apt --type=history --output /github/workspace/data.json --type=file --json --quiet --verbosity=panic"
+  args = ["analyze vanessa/salad --type=file --output=/github/workspace/data.json --json"]
 }
 
 action "list" {

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/sh -l
 
-sh -c "exec /go/bin/container-diff $*"
+echo "$@"
+sh -c "exec /go/bin/container-diff ${@}"

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,4 +1,3 @@
-#!/bin/sh -l
+#!/bin/bash
 
-echo "$@"
-sh -c "exec /go/bin/container-diff ${@}"
+exec /go/bin/container-diff "${@}"

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "$@"
-/go/bin/container-diff "${@}"
+/go/bin/container-diff ${@}

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+
+sh -c "container-diff $*"

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,3 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 
-sh -c "exec /go/bin/container-diff ${@}"
+echo "$@"
+/go/bin/container-diff "${@}"

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-sh -c "container-diff $*"
+sh -c "exec /go/bin/container-diff $*"

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -l
 
-exec /go/bin/container-diff "${@}"
+sh -c "exec /go/bin/container-diff ${@}"

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,7 @@ fi
 
 
 # Ignore these paths in the following tests.
-ignore="vendor\|out"
+ignore="vendor\|out\|actions"
 
 # Check boilerplate
 echo "Checking boilerplate..."


### PR DESCRIPTION
This pull request will add a folder, "actions" that has inside a Dockerfile, entrypoint, and instructions for using container-diff within Github Actions. The simplest example is just to run container-diff as part of a workflow:

```
workflow "Run container-diff isolated" {
  on = "push"
  resolves = ["Run container-diff"]
}
action "Run container-diff" {
  uses = "GoogleContainerTools/container-diff/actions@master"
  args = ["analyze vanessa/salad --type=file --output=/github/workspace/data.json --json"]
}
```

You could also list the data.json to show it's available for the next step:

```
workflow "Run container-diff isolated" {
  on = "push"
  resolves = ["list"]
}
action "Run container-diff" {
  uses = "GoogleContainerTools/container-diff/actions@master"
  args = ["analyze vanessa/salad --type=file --output=/github/workspace/data.json --json"]
}
action "list" {
  needs = ["Run container-diff"]
  uses = "actions/bin/sh@master"
  runs = "ls"
  args = ["/github/workspace"]
}
```
Which is what I did during testing:

![image](https://user-images.githubusercontent.com/814322/50911306-98a34000-13fd-11e9-9241-eb5ba0b06870.png)

And the general expectation is that the user would then do some additional step in the workflow that uses the data. For example, I'm going to use it to create an interactive tree diagram of the container (using the --type=file output) and then push it back to github pages.

I don't see need for different kinds or levels of actions (e.g., a subfolder in a repository can have a different Dockerfile or with a different branch) so I made just one actions folder with the Dockerfile at the root, but if you see reason to add specific ones let's chat about that.