### PR TITLE
Use top_level.txt when analyzing pip modules

### DIFF
--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -141,14 +141,6 @@ func TestDiffAndAnalysis(t *testing.T) {
 			differFlags:  []string{"--type=apt", "--no-cache"},
 			expectedFile: "apt_diff_expected.json",
 		},
-		// {
-		// 	description:  "rpm differ",
-		// 	subcommand:   "diff",
-		// 	imageA:       rpmBase,
-		// 	imageB:       rpmModified,
-		// 	differFlags:  []string{"--type=rpm"},
-		// 	expectedFile: "rpm_diff_expected.json",
-		// },
 		{
 			description:  "node differ",
 			subcommand:   "diff",
@@ -204,13 +196,6 @@ func TestDiffAndAnalysis(t *testing.T) {
 			differFlags:  []string{"--type=apt", "--no-cache"},
 			expectedFile: "apt_analysis_expected.json",
 		},
-		// {
-		// 	description:  "rpm analysis",
-		// 	subcommand:   "analyze",
-		// 	imageA:       rpmModified,
-		// 	differFlags:  []string{"--type=rpm"},
-		// 	expectedFile: "rpm_analysis_expected.json",
-		// },
 		{
 			description:  "file sorted analysis",
 			subcommand:   "analyze",

--- a/tests/pip_analysis_expected.json
+++ b/tests/pip_analysis_expected.json
@@ -7,7 +7,7 @@
         "Name": "configobj",
         "Path": "/usr/lib/python2.7/dist-packages",
         "Version": "5.0.6",
-        "Size": 89613
+        "Size": 136871
       },
       {
         "Name": "mercurial",
@@ -37,7 +37,7 @@
         "Name": "setuptools",
         "Path": "/usr/local/lib/python3.6/site-packages",
         "Version": "36.0.1",
-        "Size": 837337
+        "Size": 1282800
       },
       {
         "Name": "six",


### PR DESCRIPTION
Many egg modules contain a `top_level.txt` file, which contains metadata about the installed module's dependencies. Often the name of the egg module doesn't match up with the name of the directory containing the actual contents (e.g. a module named `PyYaml`, with its contents in a directory called `yaml`), so using this file is much more reliable than simple attempting to string match the directory. Additionally, this file gives much greater accuracy when computing the size of a package, especially when a package implicitly includes other dependencies.

Partially addresses #281 