### PR TITLE
Fix result switch while viewing with type history

### DIFF
--- a/util/template_utils.go
+++ b/util/template_utils.go
@@ -78,9 +78,9 @@ PACKAGE	IMAGE1 ({{.Image1}})	IMAGE2 ({{.Image2}}){{range .Diff.InfoDiff}}{{"\n"}
 const HistoryDiffOutput = `
 -----{{.DiffType}}-----
 
-Docker history lines found only in {{.Image1}}:{{if not .Diff.Adds}} None{{else}}{{block "list" .Diff.Adds}}{{"\n"}}{{range .}}{{print "-" .}}{{"\n"}}{{end}}{{end}}{{end}}
+Docker history lines found only in {{.Image1}}:{{if not .Diff.Adds}} None{{else}}{{block "list" .Diff.Dels}}{{"\n"}}{{range .}}{{print "-" .}}{{"\n"}}{{end}}{{end}}{{end}}
 
-Docker history lines found only in {{.Image2}}:{{if not .Diff.Dels}} None{{else}}{{block "list2" .Diff.Dels}}{{"\n"}}{{range .}}{{print "-" .}}{{"\n"}}{{end}}{{end}}{{end}}
+Docker history lines found only in {{.Image2}}:{{if not .Diff.Dels}} None{{else}}{{block "list2" .Diff.Adds}}{{"\n"}}{{range .}}{{print "-" .}}{{"\n"}}{{end}}{{end}}{{end}}
 `
 
 const MetadataDiffOutput = `


### PR DESCRIPTION
Fixes #295 
When container-diff is run with --type history the results are switched
between the images. This commit fixes this issue by changing the
template for `HistoryDiffOutput`

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>