### PR TITLE
--help: List available analyzers, improve Usage line

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -29,9 +29,11 @@ import (
 )
 
 var analyzeCmd = &cobra.Command{
-	Use:   "analyze",
-	Short: "Analyzes an image: [image]",
-	Long:  `Analyzes an image using the specifed analyzers as indicated via flags (see documentation for available ones).`,
+	Use:   "analyze image",
+	Short: "Analyzes an image: container-diff image",
+	Long: `Analyzes an image using the specifed analyzers as indicated via --type flag(s).
+
+For details on how to specify images, run: container-diff help`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if err := validateArgs(args, checkAnalyzeArgNum, checkIfValidAnalyzer); err != nil {
 			return err

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -34,9 +34,11 @@ import (
 var filename string
 
 var diffCmd = &cobra.Command{
-	Use:   "diff",
-	Short: "Compare two images: [image1] [image2]",
-	Long:  `Compares two images using the specifed analyzers as indicated via flags (see documentation for available ones).`,
+	Use:   "diff image1 image2",
+	Short: "Compare two images: container-diff image1 image2",
+	Long: `Compares two images using the specifed analyzers as indicated via --type flag(s).
+
+For details on how to specify images, run: container-diff help`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if err := validateArgs(args, checkDiffArgNum, checkIfValidAnalyzer, checkFilenameFlag); err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,8 +223,19 @@ func (d *diffTypes) Type() string {
 }
 
 func addSharedFlags(cmd *cobra.Command) {
+	sortedTypes := []string{}
+	for analyzerType := range differs.Analyzers {
+		sortedTypes = append(sortedTypes, analyzerType)
+	}
+	sort.Strings(sortedTypes)
+	supportedTypes := strings.Join(sortedTypes, ", ")
+
 	cmd.Flags().BoolVarP(&json, "json", "j", false, "JSON Output defines if the diff should be returned in a human readable format (false) or a JSON (true).")
-	cmd.Flags().VarP(&types, "type", "t", "This flag sets the list of analyzer types to use. Set it repeatedly to use multiple analyzers.")
+	cmd.Flags().VarP(&types, "type", "t",
+		fmt.Sprintf("This flag sets the list of analyzer types to use.\n"+
+			"Set it repeatedly to use multiple analyzers.\n"+
+			"Supported types: %s.",
+			supportedTypes))
 	cmd.Flags().BoolVarP(&save, "save", "s", false, "Set this flag to save rather than remove the final image filesystems on exit.")
 	cmd.Flags().BoolVarP(&util.SortSize, "order", "o", false, "Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "n", false, "Set this to force retrieval of image filesystem on each run.")


### PR DESCRIPTION
Closes #293.   
Added list of values to help for `--type` flag.  
Also noticed `Usage:` lines in `help diff` / `help analyze` didn't mention required image args, added them.

before/after diffs:

### container-diff help analyze
```diff
-Analyzes an image using the specifed analyzers as indicated via flags (see documentation for available ones).
+Analyzes an image using the specifed analyzers as indicated via --type flag(s).
+
+For details on how to specify images, run: container-diff help
 
 Usage:
-  container-diff analyze [flags]
+  container-diff analyze image [flags]
 
 Flags:
   -c, --cache-dir string   cache directory base to create .container-diff (default is $HOME).
       --force              force overwrite output file, if exists already.
   -h, --help               help for analyze
   -j, --json               JSON Output defines if the diff should be returned in a human readable format (false) or a JSON (true).
   -n, --no-cache           Set this to force retrieval of image filesystem on each run.
   -o, --order              Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.
   -w, --output string      output file to write to (default writes to the screen).
   -q, --quiet              Suppress output to stderr.
   -s, --save               Set this flag to save rather than remove the final image filesystems on exit.
-  -t, --type Diff Types    This flag sets the list of analyzer types to use. Set it repeatedly to use multiple analyzers.
+  -t, --type Diff Types    This flag sets the list of analyzer types to use.
+                           Set it repeatedly to use multiple analyzers.
+                           Supported types: apt, aptlayer, file, history, layer, metadata, node, pip, rpm, rpmlayer, size, sizelayer.
 
 Global Flags:
       --format string      Format to output diff in.
   -v, --verbosity string   This flag controls the verbosity of container-diff. (default "warning")
```

### container-diff help diff
```diff
-Compares two images using the specifed analyzers as indicated via flags (see documentation for available ones).
+Compares two images using the specifed analyzers as indicated via --type flag(s).
+
+For details on how to specify images, run: container-diff help
 
 Usage:
-  container-diff diff [flags]
+  container-diff diff image1 image2 [flags]
 
 Flags:
   -c, --cache-dir string   cache directory base to create .container-diff (default is $HOME).
   -f, --filename string    Set this flag to the path of a file in both containers to view the diff of the file. Must be used with --types=file flag.
       --force              force overwrite output file, if exists already.
   -h, --help               help for diff
   -j, --json               JSON Output defines if the diff should be returned in a human readable format (false) or a JSON (true).
   -n, --no-cache           Set this to force retrieval of image filesystem on each run.
   -o, --order              Set this flag to sort any file/package results by descending size. Otherwise, they will be sorted by name.
   -w, --output string      output file to write to (default writes to the screen).
   -q, --quiet              Suppress output to stderr.
   -s, --save               Set this flag to save rather than remove the final image filesystems on exit.
-  -t, --type Diff Types    This flag sets the list of analyzer types to use. Set it repeatedly to use multiple analyzers.
+  -t, --type Diff Types    This flag sets the list of analyzer types to use.
+                           Set it repeatedly to use multiple analyzers.
+                           Supported types: apt, aptlayer, file, history, layer, metadata, node, pip, rpm, rpmlayer, size, sizelayer.
 
 Global Flags:
       --format string      Format to output diff in.
   -v, --verbosity string   This flag controls the verbosity of container-diff. (default "warning")
```

### container-diff help
```diff
 container-diff is a CLI tool for analyzing and comparing container images.
 
 Images can be specified from either a local Docker daemon, or from a remote registry.
 To specify a local image, prefix the image ID with 'daemon://', e.g. 'daemon://gcr.io/foo/bar'.
 To specify a remote image, prefix the image ID with 'remote://', e.g. 'remote://gcr.io/foo/bar'.
 If no prefix is specified, the local daemon will be checked first.
 
 Tarballs can also be specified by simply providing the path to the .tar, .tar.gz, or .tgz file.
 
 Usage:
   container-diff [command]
 
 Available Commands:
-  analyze     Analyzes an image: [image]
-  diff        Compare two images: [image1] [image2]
+  analyze     Analyzes an image: container-diff image
+  diff        Compare two images: container-diff image1 image2
   help        Help about any command
   version     Print the version of container-diff
 
 Flags:
       --format string      Format to output diff in.
   -h, --help               help for container-diff
   -v, --verbosity string   This flag controls the verbosity of container-diff. (default "warning")
 
 Use "container-diff [command] --help" for more information about a command.
```