### PR TITLE
version: Move vX.Y.Z to version.go so it works with `go get`, add git info

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,10 +29,18 @@ var versionCmd = &cobra.Command{
 	Long:  `Print the version of container-diff.`,
 	Args:  cobra.ExactArgs(0),
 	Run: func(command *cobra.Command, args []string) {
-		fmt.Println(version.GetVersion())
+		if shortVersion {
+			fmt.Println(version.GetShortVersion())
+		} else {
+			fmt.Println(version.GetVersion())
+		}
 	},
 }
 
+// `version --short` is useful for `make release`
+var shortVersion bool
+
 func init() {
+	versionCmd.Flags().BoolVarP(&shortVersion, "short", "", false, "Output single vX.Y.Z word")
 	RootCmd.AddCommand(versionCmd)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -16,8 +16,19 @@ limitations under the License.
 
 package version
 
-var version = "v0.0.0-unset"
+import "fmt"
+
+// Bump this on release
+var version = "v0.15.0"
+
+// When built using `make` this is overridden via -ldflags
+var gitVersion = "(unknown)"
+
+// returns just the vX.Y.Z version suitable for `make release`
+func GetShortVersion() string {
+	return version
+}
 
 func GetVersion() string {
-	return version
+	return fmt.Sprintf("%s built from git %s", version, gitVersion)
 }


### PR DESCRIPTION
Followup from #293.
Previously, building with `make` was required for `version` command to output "v0.15.0"; if you just `go get` or clone and `go build .` it would always tell you "v0.0.0-unset" :-(

Now the basic vX.Y.Z is always available, and when building with `make` git information is appended:
```
$ go run . version
v0.15.0 built from git (unknown)
$ out/container-diff version
v0.15.0 built from git v0.15.0-1-gcd5a837-dirty
```
(I added `version --short` mode for `make release` to be able to extract the const embedded in version.go without anything else.  IMHO that's cleaner than slicing the output of `version` but could go either way.)

### Alternatives:
https://github.com/golang/go/issues/22147, https://github.com/golang/go/issues/29814 explore several directions for letting binaries know which git they were built from.  ldflags is indeed main current way.
Most of these don't work with bare `go get`.  
(`go generate` is not an option as go get won't run it, it's intended for the author to run and commit)

Go 1.12 has new `debug.ReadBuildInfo()` api that's supposed to automagically provide build info without needing ldflags, but only if you use go modules (?) and people reported some issues using it: https://github.com/golang/go/issues/29228.  See also https://github.com/golang-migrate/migrate/pull/172 for example attempt at using that.
