### PR TITLE
Fix concurrent map write for hardlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 out/*
+.idea/
+*.iml

--- a/pkg/util/tar_utils.go
+++ b/pkg/util/tar_utils.go
@@ -24,12 +24,15 @@ import (
 	"path/filepath"
 	"strings"
 
+	"sync"
+	"sync/atomic"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-// Map of target:linkname
-var hardlinks = make(map[string]string)
+// Thread safe Map of target:linkname
+var hardlinks sync.Map
 
 type OriginalPerm struct {
 	path string
@@ -134,19 +137,26 @@ func unpackTar(tr *tar.Reader, path string, whitelist []string) error {
 				// If it exists, create the hard link
 				resolveHardlink(linkname, target)
 			} else {
-				hardlinks[target] = linkname
+				hardlinks.Store(target, linkname)
 			}
 		}
 	}
-
-	for target, linkname := range hardlinks {
+	var resolveError atomic.Value
+	hardlinks.Range(func(key, value interface{}) bool {
+		target := key.(string)
+		linkname := value.(string)
 		logrus.Info("Resolving hard links")
 		if _, err := os.Stat(linkname); !os.IsNotExist(err) {
 			// If it exists, create the hard link
 			if err := resolveHardlink(linkname, target); err != nil {
-				return errors.Wrap(err, fmt.Sprintf("Unable to create hard link from %s to %s", linkname, target))
+				resolveError.Store(errors.Wrap(err, fmt.Sprintf("Unable to create hard link from %s to %s", linkname, target)))
+				return false
 			}
 		}
+		return true
+	})
+	if resolveError.Load() != nil {
+		return resolveError.Load().(error)
 	}
 
 	// reset all original file


### PR DESCRIPTION
This change uses `sync.Map` as suggested in #323 . It also uses a `sync.atomic.Value` container for any error that might happens while loop iteration