### PR TITLE
Add two options to handle self-signed certificates registries

### DIFF
--- a/boilerplate/boilerplate.py
+++ b/boilerplate/boilerplate.py
@@ -149,8 +149,8 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
-    # dates can be 2014, 2015, 2016, 2017, or 2018, company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018)' )
+    # dates can be 2014, 2015, 2016, 2017, 2018, 2019 or 2020 company holder names can be anything
+    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018|2019|2020)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -92,5 +93,33 @@ func TestCacheDir(t *testing.T) {
 			}
 		},
 		)
+	}
+}
+
+func TestMultiValueFlag_Set_shouldDedupeRepeatedArguments(t *testing.T) {
+	var arg multiValueFlag
+	arg.Set("value1")
+	arg.Set("value2")
+	arg.Set("value3")
+
+	arg.Set("value2")
+	if len(arg) != 3 || reflect.DeepEqual(arg, []string{"value1", "value2", "value3"}) {
+		t.Error("multiValueFlag should dedupe repeated arguments")
+	}
+}
+
+func Test_KeyValueArg_Set_shouldSplitArgument(t *testing.T) {
+	arg := make(keyValueFlag)
+	arg.Set("key=value")
+	if arg["key"] != "value" {
+		t.Error("Invalid split. key=value should be split to key=>value")
+	}
+}
+
+func Test_KeyValueArg_Set_shouldAcceptEqualAsValue(t *testing.T) {
+	arg := make(keyValueFlag)
+	arg.Set("key=value=something")
+	if arg["key"] != "value=something" {
+		t.Error("Invalid split. key=value=something should be split to key=>value=something")
 	}
 }

--- a/pkg/util/image_utils.go
+++ b/pkg/util/image_utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -116,7 +115,7 @@ func GetImage(imageName string, includeLayers bool, cacheDir string) (Image, err
 			return Image{}, errors.Wrap(err, "resolving auth")
 		}
 		start := time.Now()
-		img, err = remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+		img, err = remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(BuildTransport(ref.Context().Registry)))
 		if err != nil {
 			return Image{}, errors.Wrap(err, "retrieving remote image")
 		}

--- a/pkg/util/transport_builder.go
+++ b/pkg/util/transport_builder.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	. "github.com/google/go-containerregistry/pkg/name"
+)
+
+var tlsConfiguration = struct {
+	certifiedRegistries     map[string]string
+	skipTLSVerifyRegistries map[string]struct{}
+}{
+	certifiedRegistries:     make(map[string]string),
+	skipTLSVerifyRegistries: make(map[string]struct{}),
+}
+
+func ConfigureTLS(skipTsVerifyRegistries []string, registriesToCertificates map[string]string) {
+	tlsConfiguration.skipTLSVerifyRegistries = make(map[string]struct{})
+	for _, registry := range skipTsVerifyRegistries {
+		tlsConfiguration.skipTLSVerifyRegistries[registry] = struct{}{}
+	}
+	tlsConfiguration.certifiedRegistries = make(map[string]string)
+	for registry := range registriesToCertificates {
+		tlsConfiguration.certifiedRegistries[registry] = registriesToCertificates[registry]
+	}
+}
+
+func BuildTransport(registry Registry) http.RoundTripper {
+	var tr http.RoundTripper = newTransport()
+	if _, present := tlsConfiguration.skipTLSVerifyRegistries[registry.RegistryStr()]; present {
+		tr.(*http.Transport).TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	} else if certificatePath := tlsConfiguration.certifiedRegistries[registry.RegistryStr()]; certificatePath != "" {
+		systemCertPool := defaultX509Handler()
+		if err := appendCertificate(systemCertPool, certificatePath); err != nil {
+			logrus.WithError(err).Warnf("Failed to load certificate %s for %s\n", certificatePath, registry.RegistryStr())
+		} else {
+			tr.(*http.Transport).TLSClientConfig = &tls.Config{
+				RootCAs: systemCertPool,
+			}
+		}
+	}
+	return tr
+}
+
+// TODO replace it with "http.DefaultTransport.(*http.Transport).Clone()" once in golang 1.12
+func newTransport() http.RoundTripper {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+func appendCertificate(pool *x509.CertPool, path string) error {
+	pem, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	pool.AppendCertsFromPEM(pem)
+	return nil
+}
+
+func defaultX509Handler() *x509.CertPool {
+	systemCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		logrus.Warn("Failed to load system cert pool. Loading empty one instead.")
+		systemCertPool = x509.NewCertPool()
+	}
+	return systemCertPool
+}


### PR DESCRIPTION
Two options:

* `skip-tls-verify-registry <registry name>` will skip tls verification for given registry name
* `registry-certificate <registry name>=<path to the certificate>` will give certificate for the given registry

Fixes #326