### PR TITLE
correct version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ package version
 import "fmt"
 
 // Bump this on release
-var version = "v0.15.0"
+var version = "v0.16.0"
 
 // When built using `make` this is overridden via -ldflags
 var gitVersion = "(unknown)"


### PR DESCRIPTION
Might be better as `"(unknown)"` and set up the build tooling to set the variable.

At least in it's current state of `v0.15.0` it can be overridden