### PR TITLE
Code improvement in function readErrorsFromChannel()

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -85,11 +85,7 @@ func processImage(imageName string, errChan chan<- error) *pkgutil.Image {
 // assumes channel has already been closed
 func readErrorsFromChannel(c chan error) error {
 	errs := []string{}
-	for {
-		err, ok := <-c
-		if !ok {
-			break
-		}
+	for err := range c {
 		errs = append(errs, err.Error())
 	}
 


### PR DESCRIPTION
I think there could be a code improvement in function [readErrorsFromChannel](https://github.com/GoogleContainerTools/container-diff/blob/2db69958428be9e21daf3bce6a1c83404e7b161e/cmd/diff.go#L86) 

the for loop declared at [line 88](https://github.com/GoogleContainerTools/container-diff/blob/2db69958428be9e21daf3bce6a1c83404e7b161e/cmd/diff.go#L86) simply behaves as a
`for range`  

```diff
- for {
-		err, ok := <-c
-		if !ok {
-			break
-		}
-		errs = append(errs, err.Error())
-	}

+ for err := range c {
+	errs = append(errs, err.Error())
+}
```