### PR TITLE
Remove unnecessary global variable

### DIFF
--- a/pkg/util/tar_utils.go
+++ b/pkg/util/tar_utils.go
@@ -31,15 +31,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Thread safe Map of target:linkname
-var hardlinks sync.Map
-
 type OriginalPerm struct {
 	path string
 	perm os.FileMode
 }
 
 func unpackTar(tr *tar.Reader, path string, whitelist []string) error {
+	// Thread safe Map of target:linkname
+	var hardlinks sync.Map
+
 	originalPerms := make([]OriginalPerm, 0)
 	for {
 		header, err := tr.Next()


### PR DESCRIPTION
This PR is a small code improvement. Since the variable `hardlinks` is only used in the function `unpackTar()`, there is no need for it to have global scope. Therefore, this change will limit the variable scope to this function only.