### PR TITLE
Add Github Action workflow for building and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+---
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+        - '1.15'
+        - '1.16'
+        - '1.17'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Lint and Test
+      run: |
+        make clean test integration

--- a/boilerplate/boilerplate.py
+++ b/boilerplate/boilerplate.py
@@ -152,7 +152,7 @@ def get_regexs():
     # dates can be 2014, 2015, 2016, 2017, 2018, 2019 or 2020 company holder names can be anything
     regexs["date"] = re.compile( '(2014|2015|2016|2017|2018|2019|2020)' )
     # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
+    regexs["go_build_constraints"] = re.compile(r"^(//( \+|go:)build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     return regexs

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*


### PR DESCRIPTION
This is just a humble proposal to allow contributors and maintainers to quickly check whether contributions work as advertised (running 'make clean test integration`) without involving a local machine.

You can find a demo on how this would look like at my fork: https://github.com/cmur2/container-diff/pull/1

I guess for https://github.com/GoogleContainerTools/container-diff it's disabled to run actions of first time contributors orso, see repository settings.

I also included fixes to allow successful builds with the most recent Go stable release (1.17) which includes the noteworthy https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md