### PR TITLE
Fix incorrect mentions to --types in help messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,7 @@ Huge thanks goes out to all of our contributors for this release:
 * Fix Makefile to preserve all build artifacts
 
 # Version 0.5.1 - 11/20/17
-* Change types flag from comma separated --types list to repeated --typeflag
+* Change types flag from comma separated --types list to repeated --type flag
 * Added --filename flag to show diffs of individual files
 * Added layer caching
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -69,7 +69,7 @@ func checkFilenameFlag(_ []string) error {
 			return nil
 		}
 	}
-	return errors.New("please include --types=file with the --filename flag")
+	return errors.New("please include --type=file with the --filename flag")
 }
 
 // processImage is a concurrency-friendly wrapper around getImageForName
@@ -174,7 +174,7 @@ func diffFile(image1, image2 *pkgutil.Image) error {
 }
 
 func init() {
-	diffCmd.Flags().StringVarP(&filename, "filename", "f", "", "Set this flag to the path of a file in both containers to view the diff of the file. Must be used with --types=file flag.")
+	diffCmd.Flags().StringVarP(&filename, "filename", "f", "", "Set this flag to the path of a file in both containers to view the diff of the file. Must be used with --type=file flag.")
 	RootCmd.AddCommand(diffCmd)
 	addSharedFlags(diffCmd)
 	output.AddFlags(diffCmd)


### PR DESCRIPTION
`--types` was changed to `--type` a long while ago.