### PR TITLE
Update GitHub Action for Modern Syntax

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -1,0 +1,24 @@
+name: Test container-diff Action
+
+on: 
+  pull_request: []
+
+jobs:
+  test-container-diff:
+    name: Test container-diff
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Add more test cases here as necessary
+        args:
+          - vanessa/salad --type=file --output=./data.json --json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run container-diff
+        uses: ./actions
+        with:
+          args: ${{ matrix.args }}
+      - name: View output
+        run: cat ./data.json

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,14 @@
 name: container-diff
 
+inputs:
+  argument:
+    required: true
+    description: "String of arguments to pass to the container-diff command"
+    default: help
+
 runs:
   using: 'docker'
   image: 'action/Dockerfile'
+  args:
+    - ${{ inputs.argument }}
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,6 @@
+name: container-diff
+
+runs:
+  using: 'docker'
+  image: 'action/Dockerfile'
+

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -1,24 +1,6 @@
-FROM golang:1.11.3-stretch
+FROM debian:bookworm
 
 # docker build -f actions/Dockerfile -t googlecontainertools/container-diff .
-
-RUN apt-get update && \
-    apt-get install -y automake \
-                       libffi-dev \ 
-                       libxml2 \
-                       libxml2-dev \
-                       libxslt-dev \
-                       libxslt1-dev \
-                       git \
-                       gcc g++ \
-                       wget \
-                       locales
-
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    locale-gen
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8
 
 LABEL "com.github.actions.name"="container-diff GitHub Action"
 LABEL "com.github.actions.description"="use Container-Diff in Github Actions Workflows"
@@ -29,14 +11,10 @@ LABEL "repository"="https://www.github.com/GoogleContainerTools/container-diff"
 LABEL "homepage"="https://www.github.com/GoogleContainerTools/container-diff"
 LABEL "maintainer"="Google Inc."
 
-# Install container-diff from master
-RUN go get github.com/GoogleContainerTools/container-diff && \
-    cd ${GOPATH}/src/github.com/GoogleContainerTools/container-diff && \
-    go get && \
-    make && \
-    go install && \
-    mkdir -p /code && \
-    apt-get autoremove
+# Install container-diff latest release
+RUN apt-get update && apt-get install -y curl && \
+    curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64 && \
+    install container-diff-linux-amd64 /usr/local/bin/container-diff
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/actions/README.md
+++ b/actions/README.md
@@ -4,78 +4,49 @@ This is a Github Action to allow you to run Container Diff in a
 [Github Actions](https://help.github.com/articles/about-github-actions/#about-github-actions)
 workflow. The intended use case is to build a Docker container from the repository,
 push it to Docker Hub, and then use container-diff to extract metadata for it that
-you can use in other workflows (such as deploying to Github pages). In
-the example below, we will show you how to build a container, push
-to Docker Hub, and then container diff.  Here is the entire workflow:
+you can use in other workflows (such as deploying to Github pages). You can also run
+container diff to extract metadata for a container you've just built locally in the action.
 
-## Example 1: Run Container Diff
+## 1. Action Parameters
+
+The action accepts the following parameters:
+
+| Name | Description | Type| Default | Required |
+|------|-------------|-----|---------|----------|
+| command | main command for container-diff | string | analyze | false |
+| args  | The full list of arguments to follow container-diff (see example below) | string | help | true |
+
+See below for a simple example. Another interesting use case would be to generate metadata and upload
+to an OCI registry using [OCI Registry As Storage](https://oras.land/).
+
+## 2. Run Container Diff
 
 Given an existing container on Docker Hub, we can run container diff
 without doing any kind of build.
 
-```
-workflow "Run container-diff isolated" {
-  on = "push"
-  resolves = ["list"]
-}
+```yaml
+name: Run container-diff
 
-action "Run container-diff" {
-  uses = "GoogleContainerTools/container-diff/actions@master"
-  args = ["analyze vanessa/salad --type=file --output=/github/workspace/data.json --json"]
-}
+on: 
+  pull_request: []
 
-action "list" {
-  needs = ["Run container-diff"]
-  uses = "actions/bin/sh@master"
-  runs = "ls"
-  args = ["/github/workspace"]
-}
+jobs:
+  container-diff:
+    name: Run container-diff
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run container-diff
+        uses: GoogleContainerTools/container-diff/actions@master
+        with:
+          # Note this command is the default and does not need to be included
+          command: analyze          
+          args: vanessa/salad --type=file --output=./data.json --json
+      - name: View output
+        run: cat ./data.json
 ```
 
 In the above, we run container-diff to output apt and pip packages, history,
 and the filesystem for the container "vanessa/salad" that already exists on
 Docker Hub. We save the result to a data.json output file. The final step in 
 the workflow (list) is a courtesy to show that the data.json file is generated.
-
-## Example 2: Build, Deploy, Run Container Diff
-
-This next example is slightly more complicated in that it will run container-diff
-after a container is built and deployed from a Dockerfile present in the repository.
-
-```
-workflow "Run container-diff after deploy" {
-  on = "push"
-  resolves = ["Run container-diff"]
-}
-
-action "build" {
-  uses = "actions/docker/cli@master"
-  args = "build -t vanessa/salad ."
-}
-
-action "login" {
-  uses = "actions/docker/login@master"
-  secrets = ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
-}
-
-action "push" {
-  uses = "actions/docker/cli@master"
-  args = "push vanessa/salad"
-}
-
-action "Run container-diff" {
-  needs = ["build", "login", "push"]
-  uses = "GoogleContainerTools/container-diff/actions@master"
-  args = ["analyze vanessa/salad --type=file --output=/github/workspace/data.json --json"]
-}
-
-action "list" {
-  needs = ["Run container-diff"]
-  uses = "actions/bin/sh@master"
-  runs = "ls"
-  args = ["/github/workspace"]
-}
-```
-
-The intended use case of the above would be to, whenever you update your
-container, deploy its metadata to Github pages (or elsewhere).

--- a/actions/action.yaml
+++ b/actions/action.yaml
@@ -1,14 +1,14 @@
 name: container-diff
 
 inputs:
-  argument:
+  command:
     required: true
+    description: "Container diff command to use (defaults to analyze)"
+    default: analyze
+  args:
     description: "String of arguments to pass to the container-diff command"
     default: help
 
 runs:
   using: 'docker'
-  image: 'action/Dockerfile'
-  args:
-    - ${{ inputs.argument }}
-
+  image: 'Dockerfile'

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-echo "$@"
-/go/bin/container-diff ${@}
+command="${INPUT_COMMAND} ${INPUT_ARGS}"
+echo "container-diff ${command}"
+/usr/local/bin/container-diff ${command}


### PR DESCRIPTION
This PR is based off of #401 to honor the start of the effort by @MPV. I am adding to his start the following:

- Updating the Dockerfile for a smaller base image (and one that builds!) and one that downloads the latest release (and does not need to go build)
- Adding a local test for the action to run on a pull request
- The action.yaml should be in the actions subdirectory
- Updating the action arguments to support command and args. Command is by default "analyze" and args can be whatever the user needs for the command in question. The split isn't required, but I think it's good to provide a bit of structure. Note that arguments for container actions don't need to be in the action.yml, they can be derived from the environment via `INPUT_<NAME>`
- Updating docs in the actions/README.md and adding a table with said arguments.

Please let me know what you would like to discuss / change, happy to do that!